### PR TITLE
SMILES as REMARK in PDBQT to export RDKit mol

### DIFF
--- a/meeko/preparation.py
+++ b/meeko/preparation.py
@@ -28,7 +28,7 @@ class MoleculePreparation:
             double_bond_penalty=50, atom_type_smarts={},
             pH_value=None,
             is_protein_sidechain=False, remove_index_map=False,
-            stop_at_defaults=False):
+            stop_at_defaults=False, remove_smiles=False):
 
         self.keep_nonpolar_hydrogens = keep_nonpolar_hydrogens
         self.hydrate = hydrate
@@ -43,6 +43,7 @@ class MoleculePreparation:
         self.pH_value = pH_value
         self.is_protein_sidechain = is_protein_sidechain
         self.remove_index_map = remove_index_map
+        self.remove_smiles = remove_smiles
 
         if stop_at_defaults: return # create an object to show just the defaults (e.g. to argparse)
 
@@ -191,17 +192,17 @@ class MoleculePreparation:
 
             print('')
     
-    def write_pdbqt_string(self, remove_index_map=None):
+    def write_pdbqt_string(self, remove_index_map=None, remove_smiles=None):
         if remove_index_map is None: remove_index_map = self.remove_index_map
+        if remove_smiles is None: remove_smiles = self.remove_smiles
         if self._mol is not None:
-            return self._writer.write_string(self._mol, remove_index_map)
+            return self._writer.write_string(self._mol, remove_index_map, remove_smiles)
         else:
             raise RuntimeError('Cannot generate PDBQT file, the molecule is not prepared.')
 
-    def write_pdbqt_file(self, pdbqt_filename, remove_index_map=None):
-        if remove_index_map is None: remove_index_map = self.remove_index_map
+    def write_pdbqt_file(self, pdbqt_filename, remove_index_map=None, remove_smiles=None):
         try:
             with open(pdbqt_filename,'w') as w:
-                w.write(self.write_pdbqt_string(remove_index_map))
+                w.write(self.write_pdbqt_string(remove_index_map, remove_smiles))
         except:
             raise RuntimeError('Cannot write PDBQT file %s.' % pdbqt_filename)

--- a/scripts/mk_copy_coords.py
+++ b/scripts/mk_copy_coords.py
@@ -48,7 +48,7 @@ if __name__ == '__main__':
     ori_obmol = obutils.load_molecule_from_file(input_filename)
 
     is_dlg = coords_filename.endswith('.dlg')
-    pdbqt_mol = PDBQTMolecule(coords_filename, is_dlg=is_dlg)
+    pdbqt_mol = PDBQTMolecule.from_file(coords_filename, is_dlg=is_dlg)
 
     if not redirect_stdout and output_filename is not None:
         # If no output_filename is specified, the format will be the

--- a/scripts/mk_prepare_ligand.py
+++ b/scripts/mk_prepare_ligand.py
@@ -56,6 +56,8 @@ def cmd_lineparser():
     parser.add_argument("--double_bond_penalty", help="penalty > 100 prevents breaking double bonds", type=int)
     parser.add_argument("--remove_index_map", dest="remove_index_map",
                         action="store_true", help="do not write map of atom indices from input to pdbqt")
+    parser.add_argument("--remove_smiles", dest="remove_smiles",
+                        action="store_true", help="do not write smiles as remark to pdbqt")
     parser.add_argument("-o", "--out", dest="output_pdbqt_filename",
                         action="store", help="output pdbqt filename. Single molecule input only.")
     parser.add_argument("--multimol_outdir", dest="multimol_output_directory",
@@ -152,7 +154,7 @@ if __name__ == '__main__':
 
                 print(ligand_prepared, file=open(output_pdbqt_filename, 'w'))
             else:
-                print(ligand_prepared)
+                print(ligand_prepared, end='')
 
         # multiple molecule mode        
         else:


### PR DESCRIPTION
 - PDBQTMolecule.export_rdkit_mol() exports an RDKit molecule
   without needing to use an SDF/MOL2 file as template, by using
   a SMILES string that is included as a REMARK in the PDBQT
 - now depend on RDKit
 - PDBQTMolecule __init__ is from string, not PDBQT filename
 - PDBQTMolecule.from_file() to init from filename