### PR TITLE
Fixed github actions

### DIFF
--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -43,7 +43,7 @@ jobs:
         name: dist
         path: dist/*
     - name: Publish sdist and wheel to PyPI
-      if: ${{ success() && github.event_name == 'release' && github.event.action == 'created' }}
+      if: github.event_name == 'release' && github.event.action == 'published'
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_FORLILAB }}


### PR DESCRIPTION
Conditions were not fulfilled in order to upload the package to PyPI. This part of the GitHub actions was simply ignored during the execution. Changed it to the same condition as used for AutoDock-Vina. 