### PR TITLE
fix free_energies not parsed in ADGPU run

### DIFF
--- a/meeko/molecule_pdbqt.py
+++ b/meeko/molecule_pdbqt.py
@@ -131,7 +131,7 @@ def _read_ligand_pdbqt_file(pdbqt_string, poses_to_read=-1, energy_range=-1, is_
 
             previous_serial = serial
             i += 1
-        elif line.startswith('REMARK'):
+        elif line.startswith('REMARK') or line.startswith('USER'):
             if line.startswith('REMARK INDEX MAP') and is_first_pose:
                 integers = [int(integer) for integer in line.split()[3:]]
                 if len(integers) % 2 == 1:


### PR DESCRIPTION
From ADGPU output, REMARK does not appear at te beginning of the line and it startswith USER keyword instead. This makes the scores not parsed correctly.

```
    FINAL DOCKED STATE:
    ________________________


Run:   4 / 20
Time taken for this run:   3.293s

DOCKED: MODEL        4
DOCKED: USER    Run = 4
DOCKED: USER
DOCKED: USER    Estimated Free Energy of Binding    =  +1.03 kcal/mol  [=(1)+(2)+(3)-(4)]
DOCKED: USER
DOCKED: USER    (1) Final Intermolecular Energy     =  -9.41 kcal/mol
```