### PR TITLE
optionally allow breaking macrocycle bonds with A atom types

### DIFF
--- a/meeko/macrocycle.py
+++ b/meeko/macrocycle.py
@@ -11,7 +11,7 @@ from operator import itemgetter
 
 
 class FlexMacrocycle:
-    def __init__(self, min_ring_size=7, max_ring_size=33, double_bond_penalty=50, max_breaks=4):
+    def __init__(self, min_ring_size=7, max_ring_size=33, double_bond_penalty=50, max_breaks=4, allow_A=False):
         """Initialize macrocycle typer.
 
         Args:
@@ -25,6 +25,7 @@ class FlexMacrocycle:
         # accept also double bonds (if nothing better is found)
         self._double_bond_penalty = double_bond_penalty
         self.max_breaks = max_breaks
+        self.allow_A = allow_A
 
         self.setup = None
         self.breakable_rings = None
@@ -81,10 +82,12 @@ class FlexMacrocycle:
         bond_order = self.setup.bond[bond]['bond_order']
         if bond_order not in [1, 2, 3]: # aromatic, double, made rigid explicitly (order=1.1 from --rigidify)
             return -1
-        if self.setup.atom_type[atom_idx1] != "C":
-            return -1
-        if self.setup.atom_type[atom_idx2] != "C":
-            return -1
+        for i in (atom_idx1, atom_idx2):
+            if self.setup.atom_type[i] != "C":
+                if self.allow_A and self.setup.atom_type[i] == "A":
+                    score -= 10
+                else:
+                    return -1
         # triple bond tolerated but not preferred (TODO true?)
         if bond_order == 3:
             score -= 30

--- a/meeko/preparation.py
+++ b/meeko/preparation.py
@@ -58,6 +58,7 @@ class MoleculePreparation:
             keep_chorded_rings=False,
             keep_equivalent_rings=False,
             double_bond_penalty=50,
+            macrocycle_allow_A=False,
             rigidify_bonds_smarts=[],
             rigidify_bonds_indices=[],
             input_atom_params=None,
@@ -83,6 +84,7 @@ class MoleculePreparation:
         self.keep_chorded_rings = keep_chorded_rings
         self.keep_equivalent_rings = keep_equivalent_rings
         self.double_bond_penalty = double_bond_penalty
+        self.macrocycle_allow_A = macrocycle_allow_A
         self.rigidify_bonds_smarts = rigidify_bonds_smarts
         self.rigidify_bonds_indices = rigidify_bonds_indices
 
@@ -126,8 +128,10 @@ class MoleculePreparation:
         self.remove_smiles = remove_smiles
 
         self._bond_typer = BondTyperLegacy()
+
         self._macrocycle_typer = FlexMacrocycle(
-                self.min_ring_size, self.max_ring_size, self.double_bond_penalty)
+                self.min_ring_size, self.max_ring_size, self.double_bond_penalty,
+                allow_A=self.macrocycle_allow_A)
         self._flex_builder = FlexibilityBuilder()
         self._water_builder = HydrateMoleculeLegacy()
         self._classes_setup = {Chem.rdchem.Mol: RDKitMoleculeSetup}

--- a/scripts/mk_prepare_ligand.py
+++ b/scripts/mk_prepare_ligand.py
@@ -81,6 +81,8 @@ def cmd_lineparser():
                         action="store_true", help="equivalent rings have the same size and neighbors")
     config_group.add_argument("--min_ring_size", dest="min_ring_size",
                         type=int, help="min nr of atoms in ring for opening")
+    config_group.add_argument("--macrocycle_allow_A", action="store_true",
+                        help="allow bond break with atom type A, retyped as C")
     config_group.add_argument("-w", "--hydrate", dest="hydrate",
                         action="store_true", help="add water molecules for hydrated docking")
     config_group.add_argument(      "--charge_model", choices=["gasteiger", "zero", "from_mol2"],


### PR DESCRIPTION
Some macrocycles don't have a bond between two atoms of type C, but often there's a C-A bond. For example: https://www.rcsb.org/ligand/5P8 This PR allows breaking bonds between atoms of type A, including A-A bonds, with the caveat that parameters of C will be used for A atoms of broken bonds.