### PR TITLE
Refactoring Molecule Setups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Ignore .DS_Store files
+.DS_Store

--- a/example/chorizo/to-and-from-json.py
+++ b/example/chorizo/to-and-from-json.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import json
+
+from meeko import LinkedRDKitChorizo
+from meeko import ChorizoResidue
+from meeko import MoleculePreparation
+from meeko import RDKitMoleculeSetup
+from meeko.molsetup import MoleculeSetupEncoder
+
+with open("AHHY.pdb") as f:
+    pdb_str = f.read()
+
+chorizo = LinkedRDKitChorizo(pdb_str)
+mk_prep = MoleculePreparation()
+chorizo.flexibilize_protein_sidechain("A:TYR:4", mk_prep) # to add rdkit mol to molsetup
+residue = chorizo.residues["A:TYR:4"]
+
+# molsetup JSON conversion
+molsetup = residue.molsetup
+encoder = MoleculeSetupEncoder()
+d = encoder.default(molsetup)
+s = json.dumps(d)
+molsetup2 = RDKitMoleculeSetup.from_json(s)
+
+# chorizo residue JSON conversion
+jsonstr = residue.to_json()
+residue2 = ChorizoResidue.from_json(jsonstr) 

--- a/meeko/__init__.py
+++ b/meeko/__init__.py
@@ -34,7 +34,6 @@ from .atomtyper import AtomTyper
 from .receptor_pdbqt import PDBQTReceptor
 from .linked_rdkit_chorizo import LinkedRDKitChorizo
 from .linked_rdkit_chorizo import ChorizoResidue
-from .linked_rdkit_chorizo import ChorizoResidueEncoder
 from .linked_rdkit_chorizo import ResiduePadder
 from .linked_rdkit_chorizo import ResidueTemplate
 from .linked_rdkit_chorizo import ResidueChemTemplates
@@ -54,7 +53,7 @@ from .hydrate import Hydrate
 __all__ = ['MoleculePreparation', 'RDKitMoleculeSetup', 'MoleculeSetupEncoder',
            'pdbutils', 'geomutils', 'rdkitutils', 'utils',
            'AtomTyper', 'PDBQTMolecule', 'PDBQTReceptor', 'analysis',
-           'LinkedRDKitChorizo', 'ChorizoResidue', 'ResiduePadder', 'ResidueTemplate', 'ChorizoResidueEncoder',
+           'LinkedRDKitChorizo', 'ChorizoResidue', 'ResiduePadder', 'ResidueTemplate',
            'add_rotamers_to_chorizo_molsetups',
            'RDKitMolCreate',
            'PDBQTWriterLegacy',

--- a/meeko/__init__.py
+++ b/meeko/__init__.py
@@ -23,6 +23,7 @@ else:
 from .preparation import MoleculePreparation
 from .molsetup import RDKitMoleculeSetup
 from .molsetup import MoleculeSetup
+from .molsetup import MoleculeSetupEncoder
 from .molsetup import Restraint
 from .molsetup import UniqAtomParams
 from .utils import rdkitutils
@@ -33,6 +34,7 @@ from .atomtyper import AtomTyper
 from .receptor_pdbqt import PDBQTReceptor
 from .linked_rdkit_chorizo import LinkedRDKitChorizo
 from .linked_rdkit_chorizo import ChorizoResidue
+from .linked_rdkit_chorizo import ChorizoResidueEncoder
 from .linked_rdkit_chorizo import ResiduePadder
 from .linked_rdkit_chorizo import ResidueTemplate
 from .linked_rdkit_chorizo import ResidueChemTemplates
@@ -49,21 +51,21 @@ from .openff_xml_parser import load_openff
 from .openff_xml_parser import get_openff_epsilon_sigma
 from .hydrate import Hydrate
 
-__all__ = ['MoleculePreparation', 'RDKitMoleculeSetup',
-        'pdbutils', 'geomutils', 'rdkitutils', 'utils',
-        'AtomTyper', 'PDBQTMolecule', 'PDBQTReceptor', 'analysis',
-        'LinkedRDKitChorizo', 'ChorizoResidue', 'ResiduePadder', 'ResidueTemplate',
-        'add_rotamers_to_chorizo_molsetups',
-        'RDKitMolCreate',
-        'PDBQTWriterLegacy',
-        'reactive_typer',
-        'get_reactive_config',
-        'gridbox',
-        'oids_block_from_setup',
-        'parse_offxml',
-        'Hydrate',
-        'Restraint',
-]
+__all__ = ['MoleculePreparation', 'RDKitMoleculeSetup', 'MoleculeSetupEncoder',
+           'pdbutils', 'geomutils', 'rdkitutils', 'utils',
+           'AtomTyper', 'PDBQTMolecule', 'PDBQTReceptor', 'analysis',
+           'LinkedRDKitChorizo', 'ChorizoResidue', 'ResiduePadder', 'ResidueTemplate', 'ChorizoResidueEncoder',
+           'add_rotamers_to_chorizo_molsetups',
+           'RDKitMolCreate',
+           'PDBQTWriterLegacy',
+           'reactive_typer',
+           'get_reactive_config',
+           'gridbox',
+           'oids_block_from_setup',
+           'parse_offxml',
+           'Hydrate',
+           'Restraint',
+           ]
 
 if _has_openbabel:
     from .molsetup import OBMoleculeSetup

--- a/meeko/__init__.py
+++ b/meeko/__init__.py
@@ -23,7 +23,7 @@ else:
 from .preparation import MoleculePreparation
 from .molsetup import RDKitMoleculeSetup
 from .molsetup import MoleculeSetup
-from .molsetup import MoleculeSetupEncoder
+# from .molsetup import MoleculeSetupEncoder
 from .molsetup import Restraint
 from .molsetup import UniqAtomParams
 from .utils import rdkitutils

--- a/meeko/atomtyper.py
+++ b/meeko/atomtyper.py
@@ -22,8 +22,7 @@ class AtomTyper:
         # offatoms must be typed after charges, because offsites pull charge
         if offatom_params is not None:
             cached_offatoms = cls._cache_offatoms(molsetup, offatom_params)
-            coords = [x for x in molsetup.coord.values()]
-            cls._set_offatoms(molsetup, cached_offatoms, coords)
+            cls._set_offatoms(molsetup, cached_offatoms, molsetup.coord)
 
         if dihedral_params not in (None, 'espaloma'):
             cls._type_dihedrals(molsetup, dihedral_params)

--- a/meeko/atomtyper.py
+++ b/meeko/atomtyper.py
@@ -169,7 +169,7 @@ class AtomTyper:
                     'rotatable': False
                     }
             molsetup.charge[atomgeom.parent] = q_parent
-            molsetup.add_pseudo(**pseudo_atom)
+            molsetup.add_pseudo_atom(**pseudo_atom)
         return
 
     @staticmethod

--- a/meeko/bondtyper.py
+++ b/meeko/bondtyper.py
@@ -24,7 +24,7 @@ class BondTyperLegacy:
             """ check if the atom has more than one connection with non-ignored atoms"""
             if setup.get_element(idx) == 1:
                 return True
-            return len([x for x in setup.get_neigh(idx) if not setup.get_ignore(x)]) == 1
+            return len([x for x in setup.get_neighbors(idx) if not setup.get_ignore(x)]) == 1
         amide_bonds = [(x[0], x[1]) for x in setup.find_pattern('[NX3]-[CX3]=[O,N]')] # includes amidines
 
         # tertiary amides with non-identical substituents will be allowed to rotate

--- a/meeko/flexibility.py
+++ b/meeko/flexibility.py
@@ -232,7 +232,7 @@ class FlexibilityBuilder:
             pseudos = self._generate_closure_pseudo(setup, bond, coords_dict)
             for pseudo in pseudos:
                 pseudo['atom_type'] = "%s%d" % (pseudo['atom_type'], i)
-                pseudo_index = setup.add_pseudo(**pseudo)
+                pseudo_index = setup.add_pseudo_atom(**pseudo)
                 atom_index = pseudo['anchor_list'][0]
                 if atom_index in setup.ring_closure_info:
                     raise RuntimeError("did not expect more than one G per atom")
@@ -251,7 +251,7 @@ class FlexibilityBuilder:
         sprouts_buffer = []
         while idx < len(rigid):
             current = rigid[idx]
-            for neigh in self._current_setup.get_neigh(current):
+            for neigh in self._current_setup.get_neighbors(current):
                 bond_id = self._current_setup.get_bond_id(current, neigh)
                 bond_info = self._current_setup.get_bond(current, neigh)
                 if self._visited[neigh]:

--- a/meeko/flexibility.py
+++ b/meeko/flexibility.py
@@ -13,7 +13,8 @@ from .utils import pdbutils
 
 class FlexibilityBuilder:
 
-    def __call__(self, setup, freeze_bonds=None, root_atom_index=None, break_combo_data=None, bonds_in_rigid_rings=None, glue_pseudo_atoms=None):
+    def __call__(self, setup, freeze_bonds=None, root_atom_index=None, break_combo_data=None, bonds_in_rigid_rings=None,
+                 glue_pseudo_atoms=None):
         """ """
         self.setup = setup
         self.flexibility_models = {}
@@ -22,7 +23,7 @@ class FlexibilityBuilder:
             self._frozen_bonds = freeze_bonds[:]
         # build graph for standard molecule (no open macrocycle rings)
         model = self.build_rigid_body_connectivity()
-        model = self.set_graph_root(model, root_atom_index) # finds root if root_atom_index==None
+        model = self.set_graph_root(model, root_atom_index)  # finds root if root_atom_index==None
         self.add_flex_model(model, score=False)
 
         # evaluate possible graphs for various ring openings
@@ -33,9 +34,10 @@ class FlexibilityBuilder:
             for index in range(len(bond_break_combos)):
                 bond_break_combo = bond_break_combos[index]
                 bond_break_score = bond_break_scores[index]
-                broken_rings =     broken_rings_list[index]
-                model = self.build_rigid_body_connectivity(bond_break_combo, broken_rings, bonds_in_rigid_rings, glue_pseudo_atoms)
-                self.set_graph_root(model, root_atom_index) # finds root if root_atom_index==None
+                broken_rings = broken_rings_list[index]
+                model = self.build_rigid_body_connectivity(bond_break_combo, broken_rings, bonds_in_rigid_rings,
+                                                           glue_pseudo_atoms)
+                self.set_graph_root(model, root_atom_index)  # finds root if root_atom_index==None
                 self.add_flex_model(model, score=True, initial_score=bond_break_score)
 
         self.select_best_model()
@@ -45,25 +47,24 @@ class FlexibilityBuilder:
         del self.flexibility_models
         return self.setup
 
-
     def select_best_model(self):
         """
         select flexibility model with best complexity score
         """
-        if len(self.flexibility_models) == 1: # no macrocyle open rings
+        if len(self.flexibility_models) == 1:  # no macrocyle open rings
             best_model = list(self.flexibility_models.values())[0]
         else:
             score_sorted_models = []
             for m_id, model in list(self.flexibility_models.items()):
                 score_sorted_models.append((m_id, model['score']))
-            #print("SORTED", score_sorted_models)
+            # print("SORTED", score_sorted_models)
             score_sorted = sorted(score_sorted_models, key=itemgetter(1), reverse=True)
-            #for model_id, score in score_sorted:
+            # for model_id, score in score_sorted:
             #    print("ModelId[% 3d] score: %2.2f" % (model_id, score))
             # the 0-model is the rigid model used as reference
             best_model_id, best_model_score = score_sorted[1]
             best_model = self.flexibility_models[best_model_id]
-        
+
         setup = best_model['setup']
         del best_model['setup']
         self.setup = setup
@@ -84,7 +85,8 @@ class FlexibilityBuilder:
             model['score'] = initial_score + penalty
         self.flexibility_models[model_id] = model
 
-    def build_rigid_body_connectivity(self, bonds_to_break=None, broken_rings=None, bonds_in_rigid_rings=None, glue_pseudo_atoms=None):
+    def build_rigid_body_connectivity(self, bonds_to_break=None, broken_rings=None, bonds_in_rigid_rings=None,
+                                      glue_pseudo_atoms=None):
         """
         rigid_body_graph is the graph of rigid bodies
         ( rigid_body_id->[rigid_body_id,...] )
@@ -105,7 +107,7 @@ class FlexibilityBuilder:
             self.update_closure_atoms(bonds_to_break, glue_pseudo_atoms)
 
         # walk the mol graph to build the rigid body maps
-        self._visited = defaultdict(lambda:False)
+        self._visited = defaultdict(lambda: False)
         self._rigid_body_members = {}
         self._rigid_body_connectivity = {}
         self._rigid_body_graph = defaultdict(list)
@@ -113,10 +115,10 @@ class FlexibilityBuilder:
         # START VALUE HERE SHOULD BE MADE MODIFIABLE FOR FLEX CHAIN
         self._rigid_body_count = 0
         self.walk_rigid_body_graph(start=0)
-        model = {'rigid_body_graph' : deepcopy(self._rigid_body_graph),
-                'rigid_body_connectivity' : deepcopy(self._rigid_body_connectivity),
-                'rigid_body_members' : deepcopy(self._rigid_body_members),
-                'setup' : self._current_setup}
+        model = {'rigid_body_graph': deepcopy(self._rigid_body_graph),
+                 'rigid_body_connectivity': deepcopy(self._rigid_body_connectivity),
+                 'rigid_body_members': deepcopy(self._rigid_body_members),
+                 'setup': self._current_setup}
         return model
 
     def copy_setup(self, bond_list, broken_rings, bonds_in_rigid_rings):
@@ -130,17 +132,16 @@ class FlexibilityBuilder:
 
         for ring in broken_rings:
             for bond in setup.get_bonds_in_ring(ring):
-                if bond not in bonds_in_rigid_rings: # e.g. bonds in small rings do not rotata
+                if bond not in bonds_in_rigid_rings:  # e.g. bonds in small rings do not rotata
                     if bond in bond_list:
-                        continue # this bond has been deleted
+                        continue  # this bond has been deleted
                     bond_item = setup.get_bond(*bond)
                     if bond_item['bond_order'] == 1:
                         setup.bond[bond]['rotatable'] = True
         return setup
 
-
     def calc_max_depth(self, graph, seed_node, visited=[], depth=0):
-        maxdepth = depth 
+        maxdepth = depth
         visited.append(seed_node)
         for node in graph[seed_node]:
             if node not in visited:
@@ -149,15 +150,14 @@ class FlexibilityBuilder:
                 maxdepth = max(maxdepth, newdepth)
         return maxdepth
 
-
     def set_graph_root(self, model, root_atom_index=None):
         """ TODO this has to be made aware of the weight of the groups left
          (see 1jff:TA1)
         """
 
-        if root_atom_index is None: # find rigid group that minimizes max_depth
+        if root_atom_index is None:  # find rigid group that minimizes max_depth
             graph = deepcopy(model['rigid_body_graph'])
-            while len(graph) > 2: # remove leafs until 1 or 2 rigid groups remain
+            while len(graph) > 2:  # remove leafs until 1 or 2 rigid groups remain
                 leaves = []
                 for vertex, edges in list(graph.items()):
                     if len(edges) == 1:
@@ -182,9 +182,9 @@ class FlexibilityBuilder:
                 else:
                     root_body_index = r2
 
-        else: # find index of rigid group
+        else:  # find index of rigid group
             for body_index in model['rigid_body_members']:
-                if root_atom_index in model['rigid_body_members'][body_index]: # 1-index atoms
+                if root_atom_index in model['rigid_body_members'][body_index]:  # 1-index atoms
                     root_body_index = body_index
 
         model['root'] = root_body_index
@@ -193,18 +193,16 @@ class FlexibilityBuilder:
 
         return model
 
-
     def score_flex_model(self, model):
         """ score a flexibility model basing on the graph properties"""
         base = self.flexibility_models[0]['graph_depth']
-        score = 10 * (base-model['graph_depth'])
+        score = 10 * (base - model['graph_depth'])
         return score
-
 
     def _generate_closure_pseudo(self, setup, bond_id, coords_dict={}):
         """ calculate position and parameters of the pseudoatoms for the closure"""
         closure_pseudo = []
-        for idx in (0,1):
+        for idx in (0, 1):
             target = bond_id[1 - idx]
             anchor = bond_id[0 - idx]
             if coords_dict is None or len(coords_dict) == 0:
@@ -222,13 +220,12 @@ class FlexibilityBuilder:
                 'rotatable': False})
         return closure_pseudo
 
-
     def update_closure_atoms(self, bonds_to_break, coords_dict):
         """ create pseudoatoms required by the flexible model with broken bonds"""
 
         setup = self._current_setup
         for i, bond in enumerate(bonds_to_break):
-            setup.ring_closure_info["bonds_removed"].append(bond) # bond is pair of atom indices
+            setup.ring_closure_info["bonds_removed"].append(bond)  # bond is pair of atom indices
             pseudos = self._generate_closure_pseudo(setup, bond, coords_dict)
             for pseudo in pseudos:
                 pseudo['atom_type'] = "%s%d" % (pseudo['atom_type'], i)
@@ -239,7 +236,6 @@ class FlexibilityBuilder:
                 setup.ring_closure_info["pseudos_by_atom"][atom_index] = pseudo_index
             setup.set_atom_type(bond[0], "CG%d" % i)
             setup.set_atom_type(bond[1], "CG%d" % i)
-
 
     def walk_rigid_body_graph(self, start):
         """ recursive walk to build the graph of rigid bodies"""
@@ -270,10 +266,9 @@ class FlexibilityBuilder:
         self._rigid_body_members[current_rigid_body_count] = rigid
         for current, neigh in sprouts_buffer:
             if self._visited[neigh]: continue
-            self._rigid_body_count+=1
+            self._rigid_body_count += 1
             self._rigid_body_connectivity[current_rigid_body_count, self._rigid_body_count] = current, neigh
             self._rigid_body_connectivity[self._rigid_body_count, current_rigid_body_count] = neigh, current
             self._rigid_body_graph[current_rigid_body_count].append(self._rigid_body_count)
             self._rigid_body_graph[self._rigid_body_count].append(current_rigid_body_count)
             self.walk_rigid_body_graph(neigh)
-

--- a/meeko/hydrate.py
+++ b/meeko/hydrate.py
@@ -304,7 +304,7 @@ class HydrateMoleculeLegacy:
                                                           hb_length)
                 elif n_wat == 2:
                     # Example: C=0 (backbone oxygen)
-                    tmp_neighbors = [x for x in setup.get_neigh(neighbors[0]) if not x == a]
+                    tmp_neighbors = [x for x in setup.get_neighbors(neighbors[0]) if not x == a]
                     neighbor2_xyz =  setup.get_coord(tmp_neighbors[0])
                     positions = self._place_sp2_two_waters(anchor_xyz,
                                                            neighbor1_xyz, neighbor2_xyz,
@@ -337,7 +337,7 @@ class HydrateMoleculeLegacy:
             for water_on_anchor in waters_on_anchor:
                 tmp = setup.pdbinfo[water_anchor]
                 pdbinfo = pdbutils.PDBAtomInfo('WAT', tmp.resName, tmp.resNum, tmp.chain)
-                setup.add_pseudo(
+                setup.add_pseudo_atom(
                         coord=water_on_anchor,
                         charge=self._charge,
                         anchor_list=[water_anchor],

--- a/meeko/hydrate.py
+++ b/meeko/hydrate.py
@@ -110,7 +110,7 @@ class Hydrate:
                     # place water
                     water_center = atomgeom.calc_point(distance, theta, phi, coordinates)
                     watersetup = self.make_water()
-                    watercoords = [watersetup.coord[i] for i in watersetup.coord]
+                    watercoords = watersetup.coord
                     self.orient_water(watercoords, water_center, parent_center, is_donor)
                     for i in range(len(watercoords)):
                         watersetup.coord[i] = watercoords[i]
@@ -273,7 +273,7 @@ class HydrateMoleculeLegacy:
         # It will be the same distance for all of the water molecules
         hb_length = self._distance
 
-        for a, neighbors in setup.graph.items():
+        for a, neighbors in enumerate(setup.graph):
             atom_type = setup.get_atom_type(a)
             anchor_xyz = setup.get_coord(a)
             neighbor1_xyz = setup.get_coord(neighbors[0])

--- a/meeko/linked_rdkit_chorizo.py
+++ b/meeko/linked_rdkit_chorizo.py
@@ -13,7 +13,7 @@ from prody.atomic.selection import Selection
 
 from .writer import PDBQTWriterLegacy
 from .molsetup import MoleculeSetup
-from .molsetup import MoleculeSetupEncoder
+# from .molsetup import MoleculeSetupEncoder
 from .utils.rdkitutils import mini_periodic_table
 from .utils.rdkitutils import react_and_map
 from .utils.prodyutils import prody_to_rdkit, ALLOWED_PRODY_TYPES

--- a/meeko/linked_rdkit_chorizo.py
+++ b/meeko/linked_rdkit_chorizo.py
@@ -1048,7 +1048,7 @@ class ChorizoResidue:
 
 
     @staticmethod
-    def chorizo_residue_object_hook(obj):
+    def chorizo_residue_json_decoder(obj):
         """
         Takes an object and attempts to decode it into a chorizo residue object.
 

--- a/meeko/linked_rdkit_chorizo.py
+++ b/meeko/linked_rdkit_chorizo.py
@@ -5,6 +5,7 @@ from typing import Union
 from rdkit import Chem
 from rdkit.Chem import rdFMCS
 from rdkit.Chem import rdChemReactions
+from rdkit.Chem import rdMolInterchange
 from rdkit.Chem.AllChem import EmbedMolecule, AssignBondOrdersFromTemplate
 import prody
 from prody.atomic.atomgroup import AtomGroup
@@ -1037,7 +1038,12 @@ class ChorizoResidue:
         return
 
     def to_json(self):
-        return json.dumps(self, default=lambda o: o.__dict__)
+        return json.dumps(self, cls=ChorizoResidueEncoder)
+
+    @classmethod
+    def from_json(cls, json_string):
+        residue = json.loads(json_string, object_hook=cls.chorizo_residue_json_decoder) 
+        return residue
 
     def is_valid_residue(self):
         """
@@ -1069,19 +1075,23 @@ class ChorizoResidue:
             return obj
         # check that all the keys we expect are in the object dictionary as a safety measure
         expected_residue_keys = {"residue_id", "pdb_text", "previous_id", "next_id",
-                                 # "rdkit_mol": obj.rdkit_mol, TODO: decide on how we want to represent mols as json
+                                 "rdkit_mol",
                                  "molsetup", "molsetup_mapidx", "is_flexres_atom", "ignore_residue", "is_movable",
                                  "user_deleted", "additional_connections"}
         if set(obj.keys()) != expected_residue_keys:
             return obj
         # creates a chorizo residue and sets all the expected fields
         residue = ChorizoResidue(obj["residue_id"], obj["pdb_text"], obj["previous_id"], obj["next_id"])
-        residue.molsetup = MoleculeSetup.molsetup_object_hook(obj["molsetup"])
+        residue.molsetup = MoleculeSetup.molsetup_json_decoder(obj["molsetup"])
         residue.molsetup_mapidx = obj["molsetup_mapidx"]
         residue.is_flexres_atom = obj["is_flexres_atom"]
         residue.ignore_residue = obj["ignore_residue"]
         residue.user_deleted = obj["user_deleted"]
         residue.additional_connections = [ResidueAdditionalConnection(*v) for k, v in obj["additional_connections"]]
+        rdkit_mols = rdMolInterchange.JSONToMols(obj["rdkit_mol"])
+        if len(rdkit_mols) != 1:
+            raise ValueError(f"Expected 1 rdkit mol from json string but got {len(rdkit_mols)}")
+        residue.rdkit_mol = rdkit_mols[0]
         return residue
 
 class ResiduePadder:
@@ -1299,6 +1309,8 @@ class ChorizoResidueEncoder(json.JSONEncoder):
     JSON Encoder class for Chorizo Residue objects.
     """
 
+    molecule_setup_encoder = MoleculeSetupEncoder()
+
     def default(self, obj):
         """
         Overrides the default JSON encoder for data structures for Chorizo Residue objects.
@@ -1320,8 +1332,8 @@ class ChorizoResidueEncoder(json.JSONEncoder):
                 "pdb_text": obj.pdb_text,
                 "previous_id": obj.previous_id,
                 "next_id": obj.next_id,
-                # "rdkit_mol": obj.rdkit_mol, TODO: decide on how we want to represent mols as json
-                "molsetup": MoleculeSetupEncoder.default(self, obj.molsetup),
+                "rdkit_mol": rdMolInterchange.MolToJSON(obj.rdkit_mol),
+                "molsetup": self.molecule_setup_encoder.default(obj.molsetup),
                 "molsetup_mapidx": obj.molsetup_mapidx,
                 "is_flexres_atom": obj.is_flexres_atom,
                 "ignore_residue": obj.ignore_residue,

--- a/meeko/linked_rdkit_chorizo.py
+++ b/meeko/linked_rdkit_chorizo.py
@@ -10,9 +10,9 @@ import prody
 from prody.atomic.atomgroup import AtomGroup
 from prody.atomic.selection import Selection
 
-import meeko.molsetup
 from .writer import PDBQTWriterLegacy
 from .molsetup import MoleculeSetup
+from .molsetup import MoleculeSetupEncoder
 from .utils.rdkitutils import mini_periodic_table
 from .utils.rdkitutils import react_and_map
 from .utils.prodyutils import prody_to_rdkit, ALLOWED_PRODY_TYPES
@@ -1321,7 +1321,7 @@ class ChorizoResidueEncoder(json.JSONEncoder):
                 "previous_id": obj.previous_id,
                 "next_id": obj.next_id,
                 # "rdkit_mol": obj.rdkit_mol, TODO: decide on how we want to represent mols as json
-                "molsetup": meeko.molsetup.MoleculeSetupEncoder.default(self, obj.molsetup),
+                "molsetup": MoleculeSetupEncoder.default(self, obj.molsetup),
                 "molsetup_mapidx": obj.molsetup_mapidx,
                 "is_flexres_atom": obj.is_flexres_atom,
                 "ignore_residue": obj.ignore_residue,

--- a/meeko/linked_rdkit_chorizo.py
+++ b/meeko/linked_rdkit_chorizo.py
@@ -831,7 +831,7 @@ class LinkedRDKitChorizo:
         for res_id in self.get_valid_residues():
             molsetup = self.residues[res_id].molsetup
             wanted_atom_indices = []
-            for i, ignore in molsetup.atom_ignore.items():
+            for i, ignore in enumerate(molsetup.atom_ignore):
                 if not ignore and not self.residues[res_id].is_flexres_atom[i]:
                     wanted_atom_indices.append(i)
             for key, values in molsetup.atom_params.items():
@@ -1042,7 +1042,7 @@ class ChorizoResidue:
 
     @classmethod
     def from_json(cls, json_string):
-        residue = json.loads(json_string, object_hook=cls.chorizo_residue_json_decoder) 
+        residue = json.loads(json_string, object_hook=cls.chorizo_residue_json_decoder)
         return residue
 
     def is_valid_residue(self):

--- a/meeko/macrocycle.py
+++ b/meeko/macrocycle.py
@@ -75,27 +75,19 @@ class FlexMacrocycle:
     def _score_bond(self, bond):
         """ provide a score for the likeness of the bond to be broken"""
         bond = self.setup.get_bond_id(bond[0], bond[1])
-        atom_idx1, atom_idx2 = bond
-        score = 100
-
-        bond_order = self.setup.bond[bond]['bond_order']
-        if bond_order not in [1, 2, 3]: # aromatic, double, made rigid explicitly (order=1.1 from --rigidify)
+        if not self.setup.bond[bond]['rotatable']:
             return -1
+        atom_idx1, atom_idx2 = bond
         if self.setup.atom_type[atom_idx1] != "C":
             return -1
         if self.setup.atom_type[atom_idx2] != "C":
             return -1
-        # triple bond tolerated but not preferred (TODO true?)
-        if bond_order == 3:
-            score -= 30
-        elif (bond_order == 2):
-            score -= self._double_bond_penalty
-        if bond in self._conj_bond_list:
-            score -= 30
-        # discourage chiral atoms
-        if self.setup.get_chiral(atom_idx1) or self.setup.get_chiral(atom_idx2):
-            score -= 20
-        return score
+        # historically we returned a score <= 100, that was lower for triple
+        # bonds, chiral atoms, conjugated bonds, and double bonds. This score
+        # gets combined with the graph depth score in flexibility.py that
+        # is lower when more consecutive torsions exist in a single "branch"
+        # of the torsion tree. Any positive number can be returned here.
+        return 100
 
     def get_breakable_bonds(self, bonds_in_rigid_rings):
         """ find breaking points for rings

--- a/meeko/macrocycle.py
+++ b/meeko/macrocycle.py
@@ -28,7 +28,6 @@ class FlexMacrocycle:
 
         self.setup = None
         self.breakable_rings = None
-        self._conj_bond_list = None
 
     def collect_rings(self, setup):
         """ get non-aromatic rings of desired size and
@@ -57,20 +56,6 @@ class FlexMacrocycle:
                 bonds_in_rigid_cycles.add(bond)
 
         return breakable_rings, bonds_in_rigid_cycles 
-
-    def _detect_conj_bonds(self):
-        """ detect bonds in conjugated systems
-        """
-        # TODO this should be removed once atom typing will be done
-        conj_bond_list = []
-        # pattern = "[R0]=[R0]-[R0]=[R0]" # Does not match conjugated bonds inside  the macrocycle?
-        pattern = '*=*[*]=,#,:[*]' # from SMARTS_InteLigand.txt
-        found = self.setup.find_pattern(pattern)
-        for f in found:
-            bond = (f[1], f[2])
-            bond = (min(bond), max(bond))
-            conj_bond_list.append(bond)
-        return conj_bond_list
 
     def _score_bond(self, bond):
         """ provide a score for the likeness of the bond to be broken"""
@@ -120,7 +105,6 @@ class FlexMacrocycle:
         self.setup = setup
 
         self.breakable_rings, bonds_in_rigid_rings = self.collect_rings(setup)
-        self._conj_bond_list = self._detect_conj_bonds()
         if len(delete_these_bonds) == 0:
             breakable_bonds = self.get_breakable_bonds(bonds_in_rigid_rings)
         else:

--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -410,6 +410,38 @@ class MoleculeSetup:
     def add_atom(self, idx=None, coord=np.array([0.0, 0.0, 0.0], dtype='float'),
                  element=None, charge=0.0, atom_type=None, pdbinfo=None,
                  ignore=False, chiral=False, overwrite=False, add_atom_params=None):
+        """
+        Adds an atom with all of the atom information a user wants to specify to the molsetup. Every property is
+        optional, but possible to set.
+
+        Parameters
+        ----------
+        idx: int or None
+            atom index
+        coord: np float array of length 3
+            coordinates f the atom
+        element: int or None
+            the atomic number of the
+        charge: float
+            partial charges to be loaded for the atom
+        atom_type: string or int or None
+            needs info on exactly what these are
+        pdbinfo: string or None:
+            pdb string for the atom
+        ignore: bool
+            ignore flag for the atom
+        chiral: bool
+            indicates whether the atom should be marked as chiral
+        overwrite: bool
+            are we overwriting other atoms that may be in the same coordinate position as this one
+        add_atom_params: or None
+
+
+        Returns
+        -------
+        False if the index is already occupied and we are not overwriting existing atoms. If the method succeeds,
+        returns the index of the added atom.
+        """
         """ function to add all atom information at once;
             every property is optional
         """
@@ -434,6 +466,7 @@ class MoleculeSetup:
             self.atom_params[key].append(value)
         return idx
 
+    # TODO: are we deprecating/deleting the following or is it functionality we still want to add
     def del_atom(self, idx):
         """ remove an atom and update all data associate with it """
         pass
@@ -450,6 +483,30 @@ class MoleculeSetup:
     def add_pseudo(self, coord=np.array([0.0, 0.0, 0.0], dtype='float'), charge=0.0,
                    anchor_list=None, atom_type=None, rotatable=False,
                    pdbinfo=None, directional_vectors=None, ignore=False, overwrite=False):
+        """
+        Adds a new pseudoatom to the molsetup. Multiple bonds can be specified in "anchor_list" to support the
+        centroids of aromatic rings. If rotatable, makes the anchor atom rotatable to allow the pseudoatom movement
+
+        Parameters
+        ----------
+        coord: numpy float array of length 3
+            pseudoatom coordinates
+        charge: float
+            partial charge for the pseudoatom
+        anchor_list: list[] or None
+            a list of ints indicating multiple bonds that can be specified
+        atom_type: or None
+
+        rotatable: bool
+        pdbinfo: string or None
+        directional_vectors: or None
+        ignore: bool
+        overwrite: bool
+            indicates whether the
+        Returns
+        -------
+
+        """
         """ add a new pseudoatom
             multiple bonds can be specified in "anchor_list" to support the centroids of aromatic rings
 
@@ -469,15 +526,30 @@ class MoleculeSetup:
                       ignore=ignore,
                       overwrite=overwrite)
         # anchor atoms
-        if not anchor_list is None:
+        if anchor_list is not None:
             for anchor in anchor_list:
                 self.add_bond(idx, anchor, order=0, rotatable=rotatable)
         # directional vectors
-        if not directional_vectors is None:
+        if directional_vectors is not None:
             self.add_interaction_vector(idx, directional_vectors)
         return idx
 
     def add_bond(self, idx1, idx2, order=0, rotatable=False):
+        """
+        Adds a bond to the molsetup graph between the two indices indicated.
+
+        Parameters
+        ----------
+        idx1: int
+            first atom's index
+        idx2: int
+            second atom's index
+        order: int
+            bond order
+        rotatable: bool
+            whether the bond is rotatable
+
+        """
 
         if not idx2 in self.graph[idx1]:
             self.graph[idx1].append(idx2)
@@ -542,7 +614,11 @@ class MoleculeSetup:
         self.coord[idx] = coord
 
     def get_neigh(self, idx):
-        """ return atoms connected to atom index"""
+        """ return atoms connected to atom index
+        Note
+        ----
+        This should be get_neighbors, just neigh is nowhere near clear enough.
+        """
         return self.graph[idx]
 
     def set_chiral(self, idx, chiral):

--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -946,7 +946,7 @@ class MoleculeSetup:
         print('')
 
     @staticmethod
-    def molsetup_object_hook(obj):
+    def molsetup_json_decoder(obj):
         """
         Takes an object and attempts to decode it into a molecule setup object.
 

--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -24,7 +24,6 @@ DEFAULT_CHARGE = 0.0
 DEFAULT_ATOMIC_NUM = None
 DEFAULT_ATOM_TYPE = None
 DEFAULT_IS_IGNORE = False
-DEFAULT_IS_CHIRAL = False
 
 DEFAULT_BOND_ORDER = 0
 DEFAULT_BOND_ROTATABLE = False
@@ -168,7 +167,114 @@ class UniqAtomParams:
         return param_idxs
 
 
+
+@dataclass
+class Atom:
+    index: int
+    pdbinfo: str = DEFAULT_PDBINFO
+    charge: float = DEFAULT_CHARGE
+    atomic_num: int = DEFAULT_ATOMIC_NUM
+    atom_type: str = DEFAULT_ATOM_TYPE
+    is_ignore: bool = DEFAULT_IS_IGNORE
+    graph: list[int] = field(default_factory=list)
+    interaction_vectors: list[np.array] = field(default_factory=list)
+
+    is_dummy: bool = False
+    is_pseudo_atom: bool = False
+
+
+@dataclass
+class Bond:
+    canon_id: (int, int)
+    index1: int
+    index2: int
+    order: int = DEFAULT_BOND_ORDER
+    rotatable: bool = DEFAULT_BOND_ROTATABLE
+
+    def __init__(
+        self,
+        index1: int,
+        index2: int,
+        order: int = DEFAULT_BOND_ORDER,
+        rotatable: bool = DEFAULT_BOND_ROTATABLE,
+    ):
+        self.canon_id = self.get_bond_id(index1, index2)
+        self.index1 = index1
+        self.index2 = index2
+        self.order = order
+        self.rotatable = rotatable
+        return
+
+    @staticmethod
+    def get_bond_id(idx1: int, idx2: int):
+        """
+        Generates a consistent, "canonical", bond id from a pair of atom indices in the graph.
+
+        Parameters
+        ----------
+        idx1: int
+            atom index of one of the atoms in the bond
+        idx2: int
+            atom index of the other atom in the bond
+
+        Returns
+        -------
+        canon_id: tuple
+            a tuple of the two indices in their canonical order.
+        """
+        idx_min = min(idx1, idx2)
+        idx_max = max(idx1, idx2)
+        return idx_min, idx_max
+
+
+@dataclass
+class Ring:
+    ring_id: tuple
+    corner_flip: bool = DEFAULT_RING_CORNER_FLIP
+    graph: dict = DEFAULT_RING_GRAPH
+    is_aromatic: bool = DEFAULT_RING_IS_AROMATIC
+
+
+@dataclass
+class Restraint:
+    atom_index: int
+    target_coords: (float, float, float)
+    kcal_per_angstrom_square: float
+    delay_angstroms: float
+
+    def copy(self):
+        new_target_coords = (
+            self.target_coords[0],
+            self.target_coords[1],
+            self.target_coords[2],
+        )
+        new_restraint = Restraint(
+            self.atom_index,
+            new_target_coords,
+            self.kcal_per_angstrom_square,
+            self.delay_angstroms,
+        )
+        return new_restraint
+
+
 class MoleculeSetup:
+    """
+    Base MoleculeSetup Class, provides a way to store information about molecules for a number of purposes.
+
+    Attributes
+    ----------
+    name: str
+    is_sidechain: bool
+    true_atom_count: int
+    pseudoatom_count: int
+
+    atoms: list[Atom]
+    bond_info: dict[tuple, Bond]
+    rings: dict
+
+    rotamers: list[dict]
+    flexibility_model: dict
+    """
 
     # region CLASS CONSTANTS
     PSEUDOATOM_ATOMIC_NUM = 0
@@ -176,22 +282,19 @@ class MoleculeSetup:
 
     def __init__(self, name: str = None, is_sidechain: bool = False):
         # Molecule Setup Identity
-        self.name = name
-        self.is_sidechain = is_sidechain
-        self.true_atom_count = 0
-        self.pseudo_atom_count = 0
+        self.name: str = name
+        self.is_sidechain: bool = is_sidechain
+        self.true_atom_count: int = 0
+        self.pseudoatom_count: int = 0
 
         # Tracking atoms and bonds
         self.atoms: list[Atom] = []
-        self.bond_info = {}
-        self.rings = {}
-        self.rotamers = []
-        pass
+        self.bond_info: dict[tuple, Bond] = {}
+        self.rings: list[tuple] = []
+        self.rotamers: list[dict] = []  # TODO: revisit rotamer implementation
 
-    @classmethod
-    def from_prmtop_inpcrd(cls, prmtop, crd_filename: str):
-        # TODO: pull functionality over and clean up
-        pass
+        # TODO: redesign flexibility model to resolve some of the circular imports and to make it more structured
+        self.flexibility_model = None  # from flexibility_model - from flexibility.py
 
     # region Manually Building A MoleculeSetup
     def add_atom(
@@ -203,7 +306,6 @@ class MoleculeSetup:
         atomic_num: int = DEFAULT_ATOMIC_NUM,
         atom_type: str = DEFAULT_ATOM_TYPE,
         is_ignore: bool = DEFAULT_IS_IGNORE,
-        is_chiral: bool = DEFAULT_IS_CHIRAL,
         graph: list[int] = field(default_factory=list),
     ):
         """
@@ -214,13 +316,19 @@ class MoleculeSetup:
         Parameters
         ----------
         atom_index: int
+            atom index in the MoleculeSetup
         overwrite: bool
+            can we overwrite other atoms may be in the same atom index as this one
         pdbinfo: str
+            pdb string for the atom
         charge: float
+            partial charge to be loaded for the atom
         atomic_num: int
+            the atomic number of the atom
         atom_type: str
+            TODO: needs info
         is_ignore: bool
-        is_chiral: bool
+            ignore flag for the atom
         graph: List[List[int]]
 
         Returns
@@ -251,7 +359,13 @@ class MoleculeSetup:
 
         # Creates and adds new atom to the atom list
         new_atom = Atom(
-            atom_index, pdbinfo, charge, atomic_num, atom_type, is_ignore, is_chiral, graph
+            atom_index,
+            pdbinfo,
+            charge,
+            atomic_num,
+            atom_type,
+            is_ignore,
+            graph,
         )
         if atom_index < len(self.atoms):
             self.atoms[atom_index] = new_atom
@@ -259,7 +373,7 @@ class MoleculeSetup:
         self.atoms.append(new_atom)
         return
 
-    def add_pseudo_atom(
+    def add_pseudoatom(
         self,
         pdbinfo: str = DEFAULT_PDBINFO,
         charge: float = DEFAULT_CHARGE,
@@ -270,19 +384,36 @@ class MoleculeSetup:
         directional_vectors: list[int] = None,
     ):
         """
+        Adds a pseudoatom with all the specified attributes to the MoleculeSetup. Default values will be used for any
+        attributes with unspecified values. Multiple bonds can be specified to support the centroids of aromatic rings.
+        If rotatable, makes the anchor atom rotatable to allow the pseudoatom movement.
 
         Parameters
         ----------
-        pdbinfo
-        charge
-        atom_type
-        is_ignore
-        anchor_list
-        rotatable
+        pdbinfo: str
+            PDB string for the pseudoatom.
+        charge: float
+            partial charge for the pseudoatom
+        atom_type: str
+            TODO: needs info
+        is_ignore: bool
+            ignore flag for the pseudoatom
+        anchor_list: list[int]
+            a list of ints indicating the multiple bonds that can be specified as input
+        rotatable: bool
+            flag indicating if the anchor atom should be marked as rotatable to allow the pseudoatom movement.
         directional_vectors
+            TODO: needs info
 
         Returns
         -------
+        pseudoatom_index: int
+            The atom_index of the added pseudoatom
+
+        Raises
+        ------
+        RuntimeError:
+            When the incorrect number of anchors of pseudoatoms are found in rigid_groups in the flexibility model
 
         """
         # Places the atom at the end of the atom list.
@@ -304,6 +435,26 @@ class MoleculeSetup:
         # Adds directional vectors [Check what this is used for/if this is used]
         if directional_vectors is not None:
             self._add_interaction_vectors(pseudoatom_index, directional_vectors)
+        # If there are no specified anchor atoms,
+        if not self.flexibility_model or not anchor_list:
+            return pseudoatom_index
+        # TODO: revise this logic
+        # If there is a flexibility model in the MoleculeSetup, adds the psuedoatom to the flexibility model's rigid
+        # group tracking
+        rigid_groups_indices = []
+        for anchor in anchor_list:
+            for rigid_index, members in self.flexibility_model[
+                "rigid_body_members"
+            ].items():
+                if anchor in members:
+                    rigid_groups_indices.append(rigid_index)
+        if len(rigid_groups_indices) != 1:
+            raise RuntimeError(
+                f"anchors of pseudo atom found in {len(rigid_groups_indices)} rigid_groups (must be 1)"
+            )
+        rigid_index = rigid_groups_indices[0]
+        self.flexibility_model["rigid_body_members"][rigid_index].append(pseudoatom_index)
+        # returns the pseudoatom index
         return pseudoatom_index
 
     def delete_atom(self, atom_index: int):
@@ -331,20 +482,27 @@ class MoleculeSetup:
         rotatable: bool = DEFAULT_BOND_ROTATABLE,
     ):
         """
+        Creates a bond and adds it to all the internal data structures where atom bonds are being tracked.
 
         Parameters
         ----------
-        atom_index_1
-        atom_index_2
-        order
-        rotatable
+        atom_index_1: int
+            Atom index of one of the atoms in the bond
+        atom_index_2: int
+            Atom index of the other atom in the bond
+        order: int
+            Bond order to set for the bond
+        rotatable: bool
+            Indicates whether the bond is rotatable
 
         Returns
         -------
+        None
 
         Raises
         ------
-
+        IndexError:
+            When one or more the given bond atom indices do not exist in the MoleculeSetup
         """
         # Checks that both of the atom indices provided are valid indices, otherwise throws an error
         if len(self.atoms) <= atom_index_1 or len(self.atoms) <= atom_index_2:
@@ -363,15 +521,18 @@ class MoleculeSetup:
 
     def delete_bond(self, atom_index_1: int, atom_index_2: int):
         """
+        Deletes a bond from the molecule setup.
 
         Parameters
         ----------
-        atom_index_1
-        atom_index_2
+        atom_index_1: int
+            The atom index of one of the atoms in the bond to delete
+        atom_index_2: int
+            The atom index of the other atom in the bond to delete
 
         Returns
         -------
-
+        None
         """
         # Gets canon bond id for the bond to delete
         canon_bond_id = Bond.get_bond_id(atom_index_1, atom_index_2)
@@ -383,15 +544,65 @@ class MoleculeSetup:
         return
 
     def add_rotamers(
-        self, index_list: list[(int, int, int, int)], angles_list: np.ndarray
+        self, index_list: list[(int, int, int, int)], angle_list: np.ndarray
     ):
-        # TODO: pull implementation over
-        pass
+        """
+        Adds rotamers to the internal record of rotamers.
 
-    def count_true_atoms(self):
-        for atom in self.atoms:
-            if not atom.is_pseudo_atom and not atom.is_dummy:
-                self.true_atom_count += 1
+        Parameters
+        ----------
+        index_list: list[(int, int, int, int)]
+        angle_list: np.ndarray
+
+        Returns
+        -------
+        None
+        """
+        # It's unclear how this will work without the coordinates in the moleculesetup. food for thought.
+        # TODO: address issues with the lack of coords and add detail in function comment
+        rotamers = {}
+        for (idx1, idx2, idx3, idx4), angle in zip(index_list, angle_list):
+            bond_id = Bond.get_bond_id(idx2, idx3)
+            if bond_id in rotamers:
+                raise RuntimeError("repeated bond %d-$d" % bond_id)
+            if not self.bond_info[bond_id].rotatable:
+                raise RuntimeError(
+                    "trying to add rotamer for non rotatable bond %d-%d" % bond_id
+                )
+            # d0 = calcDihedral(xyz[i1], xyz[i2], xyz[i3], xyz[i4])
+            dihedral = 0  # TODO: fix this
+            rotamers[bond_id] = angle - dihedral
+        self.rotamers.append(rotamers)
+        return
+
+    def delete_rotamers(
+        self,
+        bond_id_list: list[tuple] = None,
+        index_list: list[(int, int, int, int)] = None,
+    ):
+        """
+        Deletes rotamers from the internal list of rotamers, either by using bond ids or by generating bond ids from a
+        list of input indices.
+
+        Parameters
+        ----------
+        bond_id_list: list[tuple]
+        index_list: list[(int, int, int, int)]
+
+        Returns
+        -------
+        None
+        """
+        # loops through the index list, generates bond ids from the provided indices and adds them to the bond_id_list
+        if index_list is not None:
+            for idx1, idx2, idx3, idx4 in index_list:
+                bond_id = Bond.get_bond_id(idx2, idx3)
+                bond_id_list.append(bond_id)
+        # deletes all bond_ids in bond_id_list from self.rotamers
+        if bond_id_list is not None:
+            for bond_id in bond_id_list:
+                if bond_id in self.rotamers:
+                    del self.rotamers[bond_id]
         return
 
     def _add_interaction_vectors(self, atom_index: int, vector_list: list[np.array]):
@@ -416,17 +627,85 @@ class MoleculeSetup:
         """
         if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
             raise IndexError(
-                "INTERACTION_VECTORS: provided atom index is out of range or is a dummy atom"
+                "INTERACTION_VECTORS: provided atom index is out of range or is a dummy atom."
             )
         for vector in vector_list:
             self.atoms[atom_index].interaction_vectors.append(vector)
         return
 
+    def count_true_atoms(self):
+        """
+        Counts the number of atoms in the MoleculeSetup that are not pseudo_atoms or marked as dummy atoms, and
+        sets self.true_atom_count to that number.
+
+        Returns
+        -------
+        true_atom_count: int
+            The number of atoms currently in the MoleculeSetup that are not dummy atoms or pseudo_atoms.
+        """
+        for atom in self.atoms:
+            if not atom.is_pseudo_atom and not atom.is_dummy:
+                self.true_atom_count += 1
+        return self.true_atom_count
+
+    # this might void the graph connections and everything in bonds, might need to add a dict of the changes we're
+    # making and then use that save this for a future push.
+    def clean_atoms(self, remove_pseudoatoms: bool = False):
+        """
+        Cleans dummy and potentially also pseudoatoms from the MoleculeSetup so only true atoms remain. Note that this
+        is pretty slow and should not be done often.
+
+        Parameters
+        ----------
+        remove_pseudoatoms: bool
+            Indicates if we want to remove all the pseudoatoms from the MoleculeSetup.
+
+        Returns
+        -------
+        The number of atoms removed from the MoleculeSetup.
+        """
+        new_atoms = []
+        removed_atom_count = 0
+        atom_index_mapping = {}
+        for atom in self.atoms:
+            if remove_pseudoatoms and atom.is_pseudo_atom:
+                removed_atom_count += 1
+                continue
+            if atom.is_dummy:
+                removed_atom_count += 1
+                continue
+            atom.index = atom.index - removed_atom_count
+            new_atoms.append(atom)
+        self.atoms = new_atoms
+        if remove_pseudoatoms:
+            self.pseudoatom_count = 0
+        return removed_atom_count
+
     # endregion
 
     # region Getters and Setters
+    # ALL NEED DOCUMENTATION
 
     def get_pdbinfo(self, atom_index: int):
+        """
+        Retrieves the PDB Info string for the atom with the specified atom index.
+
+        Parameters
+        ----------
+        atom_index: int
+            Atom index to retrieve data for.
+
+        Returns
+        -------
+        pdbinfo: str
+            A string containing the pdb information for the atom
+
+        Raises
+        ------
+        IndexError:
+            When the provided atom index does not exist in the MoleculeSetup or the atom index does not contain
+            data.
+        """
         if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
             raise IndexError(
                 "GET_PDBINFO: provided atom index is out of range or is a dummy atom"
@@ -434,6 +713,25 @@ class MoleculeSetup:
         return self.atoms[atom_index].pdbinfo
 
     def get_charge(self, atom_index: int):
+        """
+        Retrieves the partial charge for the atom with the specified atom index.
+
+        Parameters
+        ----------
+        atom_index: int
+            Atom index to retrieve data for.
+
+        Returns
+        -------
+        charge: float
+            The charge associated with the atom
+
+        Raises
+        ------
+        IndexError:
+            When the provided atom index does not exist in the MoleculeSetup or the atom index does not contain
+            data.
+        """
         if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
             raise IndexError(
                 "GET_CHARGE: provided atom index is out of range or is a dummy atom"
@@ -441,6 +739,25 @@ class MoleculeSetup:
         return self.atoms[atom_index].charge
 
     def get_atomic_num(self, atom_index: int):
+        """
+        Retrieves the atomic number for the atom with the specified atom index.
+
+        Parameters
+        ----------
+        atom_index: int
+            Atom index to retrieve data for.
+
+        Returns
+        -------
+        atomic_num: int
+            The atomic number associated with an atom.
+
+        Raises
+        ------
+        IndexError:
+            When the provided atom index does not exist in the MoleculeSetup or the atom index does not contain
+            data.
+        """
         if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
             raise IndexError(
                 "GET_ATOMIC_NUM: provided atom index is out of range or is a dummy atom"
@@ -448,6 +765,25 @@ class MoleculeSetup:
         return self.atoms[atom_index].atomic_num
 
     def get_atom_type(self, atom_index: int):
+        """
+        Retrieves the atom type for the atom with the specified atom index.
+
+        Parameters
+        ----------
+        atom_index: int
+            Atom index to retrieve data for.
+
+        Returns
+        -------
+        charge: str
+            The atom index associated with the atom
+
+        Raises
+        ------
+        IndexError:
+            When the provided atom index does not exist in the MoleculeSetup or the atom index does not contain
+            data.
+        """
         if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
             raise IndexError(
                 "GET_ATOM_TYPE: provided atom index is out of range or is a dummy atom"
@@ -487,20 +823,51 @@ class MoleculeSetup:
         return None
 
     def get_is_ignore(self, atom_index: int):
+        """
+        Retrieves the is_ignore boolean for the atom with the specified atom index.
+
+        Parameters
+        ----------
+        atom_index: int
+            Atom index to retrieve data for.
+
+        Returns
+        -------
+        is_ignore: bool
+            Indicates whether a particular atom should be ignored
+
+        Raises
+        ------
+        IndexError:
+            When the provided atom index does not exist in the MoleculeSetup or the atom index does not contain
+            data.
+        """
         if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
             raise IndexError(
                 "GET_IS_IGNORE: provided atom index is out of range or is a dummy atom"
             )
         return self.atoms[atom_index].is_ignore
 
-    def get_is_chiral(self, atom_index: int):
-        if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
-            raise IndexError(
-                "GET_IS_CHIRAL: provided atom index is out of range or is a dummy atom"
-            )
-        return self.atoms[atom_index].is_chiral
-
     def get_neighbors(self, atom_index: int):
+        """
+        Retrieves the partial charge for the atom with the specified atom index.
+
+        Parameters
+        ----------
+        atom_index: int
+            Atom index to retrieve data for.
+
+        Returns
+        -------
+        graph: list[int]
+            The graph of the atoms connections to other atoms.
+
+        Raises
+        ------
+        IndexError:
+            When the provided atom index does not exist in the MoleculeSetup or the atom index does not contain
+            data.
+        """
         if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
             raise IndexError(
                 "GET_GRAPH: provided atom index is out of range or is a dummy atom"
@@ -516,72 +883,94 @@ class MoleculeSetup:
 
     # endregion
 
-    # def get_bonds_in_ring
-    # def walk_recursive
-    # def perceive_rings
+    def merge_terminal_atoms(self, indices):
+        """
+        Primarily for merging hydrogens, but will merge the data for any atom or pseudoatom that is bonded to only one
+        other atom.
 
-    # def merge_terminal_atoms(self, indices):
-    #     """
-    #     Primarily for merging hydrogens, but will merge the data for any atom or pseudoatom that is bonded to only one
-    #     other atom.
-    #
-    #     Parameters
-    #     ----------
-    #     indices: list
-    #         A list of indices to merge
-    #
-    #     Returns
-    #     -------
-    #     None
-    #     """
-    #     for index in indices:
-    #         if len(self.get_neighbors(index)) != 1:
-    #             msg = "Atempted to merge atom %d with %d neighbors. "
-    #             msg += "Only atoms with one neighbor can be merged."
-    #             msg = msg % (index + 1, self.get_neighbors(index))
-    #             raise RuntimeError(msg)
-    #         neighbor_index = self.get_neighbors(index)[0]
-    #         self.atoms[neighbor_index].charge += self.get_charge(index)
-    #         self.atoms[index].charge = 0.0
-    #         self.atoms[index].is_ignore = True
-    #     return
+        Parameters
+        ----------
+        indices: list
+            A list of indices to merge
+
+        Returns
+        -------
+        None
+        """
+        for index in indices:
+            if len(self.get_neighbors(index)) != 1:
+                msg = "Atempted to merge atom %d with %d neighbors. "
+                msg += "Only atoms with one neighbor can be merged."
+                msg = msg % (index + 1, self.get_neighbors(index))
+                raise RuntimeError(msg)
+            neighbor_index = self.get_neighbors(index)[0]
+            self.atoms[neighbor_index].charge += self.get_charge(index)
+            self.atoms[index].charge = 0.0
+            self.atoms[index].is_ignore = True
+        return
 
 
 # TODO: RENAME THIS TO NOT BE WORD VOMIT, CLEAN UP - Sets all the requirements for if you're building
 # A moleculesetup with an external toolkit like RDKit or OB
-class MoleculeSetupExternalToolBuild(ABC):
+class MoleculeSetupExternalToolkit(ABC):
+    """
+    Additional functions and requirements to extend the MoleculeSetup class in order to use it with  external toolkits
+    such as RDKit.
+
+    Required Attributes
+    -------------------
+    dihedral_interactions: list
+        A list of fourier series [add detail]
+    """
 
     @staticmethod
-    def are_fourier_series_identical(fs1, fs2):
+    def are_fourier_series_identical(series1: list, series2: list) -> bool:
         """
-        NOT MODIFIED YET
+        Compares two fourier series represented as lists of dictionaries.
+
+        Parameters
+        ----------
+        series1: list[dict]
+            The first fourier series to compare.
+        series2: list[dict]
+            The second fourier series to compare.
+
+        Returns
+        -------
+        A bool indicicating whether the fourier series are equal.
         """
+        # Gets the indices of both series by periodicity and checks for equality
         index_by_periodicity1 = {
-            fs1[index]["periodicity"]: index for index in range(len(fs1))
+            series1[index]["periodicity"]: index for index in range(len(series1))
         }
         index_by_periodicity2 = {
-            fs2[index]["periodicity"]: index for index in range(len(fs2))
+            series2[index]["periodicity"]: index for index in range(len(series2))
         }
         if index_by_periodicity1 != index_by_periodicity2:
             return False
+        # After establishing equality of the indices, loops through periodicity abd checks that the values stored in
+        # each fourier series dictionary are equal.
         for periodicity in index_by_periodicity1:
             index1 = index_by_periodicity1[periodicity]
             index2 = index_by_periodicity2[periodicity]
             for key in ["k", "phase", "periodicity"]:
-                if fs1[index1][key] != fs2[index2][key]:
+                if series1[index1][key] != series2[index2][key]:
                     return False
         return True
 
     def add_dihedral_interaction(self, fourier_series):
         """
+        Adds a safe copy of the input fourier series to the dihedral_interactions list if the fourier series is not
+        already in the list.
 
         Parameters
         ----------
-        fourier_series
+        fourier_series: list[dict]
 
         Returns
         -------
-
+        index: int
+            The index of the input fourier series in the dihedral interactions list.
         """
         index = 0
         for existing_fs in self.dihedral_interactions:
@@ -605,7 +994,7 @@ class MoleculeSetupExternalToolBuild(ABC):
         pass
 
     @abstractmethod
-    def find_pattern(self):
+    def find_pattern(self, smarts: str):
         pass
 
     @abstractmethod
@@ -615,16 +1004,30 @@ class MoleculeSetupExternalToolBuild(ABC):
     pass
 
 
-class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolBuild):
+class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolkit):
     """
     Subclass of MoleculeSetup, used to represent MoleculeSetup objects working with RDKit objects
 
     Attributes
     ----------
     mol : rdkit.Chem.rdchem.Mol
-        an RDKit Mol object to base the Molecule Setup on
-    modified_atom_positions :
-        list of dictionaries where keys are atom indices
+        An RDKit Mol object to base the Molecule Setup on.
+    modified_atom_positions: list
+        List of dictionaries where keys are atom indices, Used to store sets of coordinates, e.g. docked poses, as
+        dictionaries indexed by the atom index, because not all atoms need to have new coordinates specified.
+        Unspecified hydrogen positions bonded to modified heavy atom positions are to be calculated "on-the-fly".
+    dihedral_interactions: list[]
+        A list of fourier series, each of which are represented as a list of dictionaries.
+    dihedral_partaking_atoms: dict()
+        a mapping from atom index (int?) to dihedral index (int?)
+    dihedral_labels: dict()
+        a mapping from atom index to a string dihedral labels
+    atom_to_ring_id: dict()
+        mapping of atom index to ring id of each atom belonging to the ring
+    ring_corners: dict()
+        unclear what this is a mapping of, but is used to store corner flexibility for the rings
+    rmsd_symmetry_indices: tuple
+        Tuples of the indices of the molecule's atoms that match a substructure query. needs info.
 
     Methods
     -------
@@ -632,21 +1035,49 @@ class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolBuild):
         constructor for the RDKitMoleculeSetup object (consider adapting to init?)
     """
 
+    def __init__(self, name: str = None, is_sidechain: bool = False):
+        super().__init__(name, is_sidechain)
+        modified_atom_positions = []
+
     @classmethod
     def from_mol(
         cls,
-        mol,
-        keep_chorded_rings=False,
-        keep_equivalent_rings=False,
-        assign_charges=True,
-        conformer_id=-1,
+        mol: Chem.Mol,
+        keep_chorded_rings: bool = False,
+        keep_equivalent_rings: bool = False,
+        assign_charges: bool = True,
+        conformer_id: int = -1,
     ):
+        """
+
+        Parameters
+        ----------
+        mol: rdkit.Chem.rdchem.Mol
+            RDKit Mol object to build the RDKitMoleculeSetup from.
+        keep_chorded_rings: bool
+        keep_equivalent_rings: bool
+        assign_charges: bool
+        conformer_id: int
+
+        Returns
+        -------
+        molsetup: RDKitMoleculeSetup
+            A populated RDKitMoleculeSetup object
+
+        Raises
+        ------
+        ValueError:
+            If the RDKit Mol has implicit Hydrogens or if there are no conformers for the given RDKit Mol
+        """
+        # Checks if the input molecule is valid
         if cls.has_implicit_hydrogens(mol):
             raise ValueError("RDKit molecule has implicit Hs. Need explicit Hs.")
         if mol.GetNumConformers() == 0:
             raise ValueError(
                 "RDKit molecule does not have a conformer. Need 3D coordinates."
             )
+
+        # Gets the RDKit Conformer that we are going to load into the molecule setup
         rdkit_conformer = mol.GetConformer(conformer_id)
         if not rdkit_conformer.Is3D():
             warnings.warn(
@@ -656,6 +1087,9 @@ class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolBuild):
         if mol.GetNumConformers() > 1 and conformer_id == -1:
             msg = "RDKit molecule has multiple conformers. Considering only the first one."
             print(msg, file=sys.stderr)
+
+        # Creating and populating the molecule setup with properties from RDKit as well as calculated values from our
+        # functions
         molsetup = cls()
         molsetup.mol = mol
         molsetup.atom_true_count = molsetup.get_num_mol_atoms()
@@ -676,34 +1110,150 @@ class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolBuild):
 
         return molsetup
 
-    # @classmethod
-    # def from_mol(
-    #     cls,
-    #     mol: rdkit.Chem.Mol,
-    #     keep_chorded_rings: bool = False,
-    #     keep_equivalent_rings: bool = False,
-    #     assign_charges: bool = True,
-    #     conformer_id: int = 1,
-    # ):
-    #     # Checks if the input molecule is valid
-    #     if has_implicit_hydrogens(mol):
-    #         raise ValueError("RDKit molecule has implicit Hs. Need explicit Hs.")
-    #     if mol.GetNumConformers(mol) == 0:
-    #         raise ValueError(
-    #             "RDKit molecule does not have a conformer. Need 3D coordinates."
-    #         )
-    #
-    #     # Gets the RDKit Conformer that we are going to load into the molecule setup
-    #     rdkit_conformer = mol.GetConformer(conformer_id)
-    #
-    #     # Creating and populating the molecule setup with properties from RDKit
-    #
-    #     pass
+    # region Ring Construction
+
+    # NOTE: This is a candidate for moving to utils
+    @staticmethod
+    def get_bonds_in_ring(ring: list[int]):
+        """
+        Takes as input a list of atom indices corresponding to atoms in a ring and returns a list of all the bonds ids
+        in the ring.
+
+        Parameters
+        ----------
+        ring: list[int]
+            A list of atom indices of the atoms in a ring.
+
+        Returns
+        -------
+        A list of canonical bond id tuples for the bonds in the ring.
+        """
+        bonds = []
+        num_indices = len(ring)
+        for i in range(num_indices):
+            bond = (ring[i], ring[(i + 1) % num_indices])
+            bond = Bond.get_bond_id(bond[0], bond[1])
+            bonds.append(bond)
+        return bonds
+
+    def _is_ring_aromatic(self, ring_atom_indices: list[(int, int)]):
+        """
+        Determines whether a ring is aromatic.
+
+        Parameters
+        ----------
+        ring_atom_indices: the atom indices in the ring.
+
+        Returns
+        -------
+        A boolean indicating whether this ring is aromatic.
+        """
+        for atom_idx1, atom_idx2 in self.get_bonds_in_ring(ring_atom_indices):
+            bond = self.mol.GetBondBetweenAtoms(atom_idx1, atom_idx2)
+            if not bond.GetIsAromatic():
+                return False
+        return True
+
+    @staticmethod
+    def _construct_old_graph(atom_list: list[Atom]):
+        """
+        To support older implementations of helper functions in Meeko, takes a list of atoms and uses it to create a
+        list of each atom's graph value, where the index of a graph in the list corresponds to the atom's atom_index.
+
+        Parameters
+        ----------
+        atom_list: list[Atom]
+            A list of populated Atom objects.
+
+        Returns
+        -------
+        A list of lists of ints, where each list of ints represents the bonds from that atom index to other atom
+        indices.
+        """
+        output_graph = []
+        for atom in atom_list:
+            output_graph.append(atom.graph)
+        return output_graph
+
+    def _recursive_graph_walk(
+        self, idx: int, collected: list[int] = None, exclude: list[int] = None
+    ):
+        """
+        Recursively walks through a molecular graph and returns bond-connected subgroups.
+
+        Parameters
+        ----------
+        idx: int
+            atom index to start the recursive walk from
+        collected: list[int]
+            a list of connected subgroups
+        exclude: list[int]
+            a list of atom indices to exclude from the final walk.
+
+        Returns
+        -------
+        A list of ints indicating the subgroups that are bond-connected.
+        """
+        if collected is None:
+            collected = []
+        if exclude is None:
+            exclude = []
+        for neighbor in self.get_neighbors(idx):
+            if neighbor in collected or neighbor in exclude:
+                continue
+            collected.append(neighbor)
+            self._recursive_graph_walk(neighbor, collected.exclude)
+        return collected
+
+    def perceive_rings(self, keep_chorded_rings: bool, keep_equivalent_rings: bool):
+        """
+        Uses Hanser-Jauffret-Kaufmann exhaustive ring detection to find the rings in the molecule
+
+        Parameters
+        ----------
+        keep_chorded_rings: bool
+            Indicates whether we want to keep chorded rings
+        keep_equivalent_rings: bool
+            Indicates whether we want to keep equivalent rings
+
+        Returns
+        -------
+        None
+        """
+        # uses Hanser-Jauffret-Kaufmann exhaustive ring detection to get the rings in the molecule
+        old_graph = _construct_old_graph(self.atoms)
+        hjk_ring_detection = utils.HJKRingDetection(old_graph)
+        rings = hjk_ring_detection.scan(keep_chorded_rings, keep_equivalent_rings)
+        for ring_atom_indices in rings:
+            ring_to_add = Ring(ring_atom_indices)
+            if _is_ring_aromatic(ring_atom_indices):
+                ring_to_add.is_aromatic = True
+            for atom_idx in ring_atom_indices:
+                # TODO: add it to some sort of atom to ring id tracking thing -> add to atom data structure
+                ring_to_add.graph = self._recursive_graph_walk(
+                    atom_idx, collected=[], exclude=list(ring_atom_indices)
+                )
+            self.rings[ring_atom_indices] = ring_to_add
+        return
+
+    # endregion
 
     def get_conformer_with_modified_positions(self, new_atom_positions):
-        # we operate on one conformer at a time because SetTerminalAtomPositions
-        # acts on all conformers of a molecule, and we don't want to guarantee
-        # that all conformers require the same set of terminal atoms to be updated
+        """
+        Gets a conformer with the specified new atom positions.
+        We operate on one conformer at a time because SetTerminalAtomPositions acts on all conformers of a molecule,
+        and we do not want to guarantee that all conformers require the same set of terminal atoms to be updated.
+
+        Parameters
+        ----------
+        new_atom_positions:
+            The new atom positions we want to use.
+
+        Returns
+        -------
+        new_conformer:
+            A new conformer with the input new atom positions.
+        """
         new_mol = Chem.Mol(self.mol)
         new_conformer = Chem.Conformer(self.mol.GetConformer())
         is_set_list = [False] * self.mol.GetNumAtoms()
@@ -721,6 +1271,20 @@ class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolBuild):
         return new_conformer
 
     def get_mol_with_modified_positions(self, new_atom_positions_list=None):
+        """
+        Modifies the stored RDKit Mol to a new set of atom positions, either those provided or the ones stored in
+        self.modified_atom_positions.
+
+        Parameters
+        ----------
+        new_atom_positions_list:
+            New atom positions to add to the RDKit Mol object.
+
+        Returns
+        -------
+        new_mol: rdkit.Chem.rdchem.Mol
+            A new RDKit Mol object with conformers that have the desired new atom positions.
+        """
         if new_atom_positions_list is None:
             new_atom_positions_list = self.modified_atom_positions
         new_mol = Chem.Mol(self.mol)
@@ -730,33 +1294,17 @@ class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolBuild):
             new_mol.AddConformer(conformer, assignId=True)
         return new_mol
 
+    # TODO: Add more inline comments and clean up this function
     def get_smiles_and_order(self):
         """
-        return the SMILES after Chem.RemoveHs()
-        and the mapping between atom indices in smiles and self.mol
-        """
+        Returns the SMILES string and the mapping between atom indices in the SMILES and self.molof an atom after
+        running RDKit's RemoveHs function.
 
-        ### # support sidechains in which not all real atoms are included in PDBQT
-        ### ignored = []
-        ### for atom in self.mol.GetAtoms():
-        ###     index = atom.GetIdx()
-        ###     if self.atom_ignore[index]:
-        ###         ignored.append(index)
-        ### if len(ignored) > 0: # e.g. sidechain padded with amides
-        ###     mol_no_ignore = Chem.EditableMol(self.mol)
-        ###     for index in sorted(ignored, reverse=True):
-        ###         mol_no_ignore.RemoveAtom(index)
-        ###     # remove dangling Hs
-        ###     dangling_hs = []
-        ###     for atom in mol_no_ignore.GetMol().GetAtoms():
-        ###         if atom.GetAtomicNum() == 1:
-        ###             if len(atom.GetNeighbors()) == 0:
-        ###                 dangling_hs.append(atom.GetIdx())
-        ###     for index in sorted(dangling_hs, reverse=True):
-        ###         mol_no_ignore.RemoveAtom(index)
-        ###     mol_no_ignore = mol_no_ignore.GetMol()
-        ###     Chem.SanitizeMol(mol_no_ignore)
-        ### else:
+        Returns
+        -------
+        smiles:
+        order:
+        """
         mol_no_ignore = self.mol
 
         # 3D SDF files written by other toolkits (OEChem, ChemAxon)
@@ -861,20 +1409,52 @@ class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolBuild):
         order = {noH_to_H[i]: order[i] + 1 for i in range(len(order))}  # 1-index
         return smiles, order
 
-    def find_pattern(self, smarts):
+    def find_pattern(self, smarts: str):
+        """
+        Given a SMARTS pattern, finds substruct matches in the molecule.
+
+        Parameters
+        ----------
+        smarts:
+            A SMARTS string to find in the RDKit Mol object
+
+        Returns
+        -------
+        The substruct matches in the RDKit Mol for the given SMARTS.
+        """
         p = Chem.MolFromSmarts(smarts)
         return self.mol.GetSubstructMatches(p)
 
     def get_mol_name(self):
+        """
+        Gets the RDKit Mol's name from self.mol.
+
+        Returns
+        -------
+        If the mol has a name, returns the name property.
+        """
         if self.mol.HasProp("_Name"):
             return self.mol.GetProp("_Name")
         else:
             return None
 
     def get_num_mol_atoms(self):
+        """
+        Gets the number of atoms in the RDKit Mol object.
+
+        Returns
+        -------
+        Number of atoms in the RDKit Mol object.
+        """
         return self.mol.GetNumAtoms()
 
     def get_equivalent_atoms(self):
+        """
+
+        Returns
+        -------
+
+        """
         return list(Chem.CanonicalRankAtoms(self.mol, breakTies=False))
 
     @staticmethod
@@ -1035,89 +1615,3 @@ class OBMoleculeSetup(MoleculeSetup):
     def copy(self):
         """return a copy of the current setup"""
         return OBMoleculeSetup(template=self)
-
-
-@dataclass
-class Atom:
-    index: int
-    pdbinfo: str = DEFAULT_PDBINFO
-    charge: float = DEFAULT_CHARGE
-    atomic_num: int = DEFAULT_ATOMIC_NUM
-    atom_type: str = DEFAULT_ATOM_TYPE
-    is_ignore: bool = DEFAULT_IS_IGNORE
-    is_chiral: bool = DEFAULT_IS_CHIRAL
-    graph: list[int] = field(default_factory=list)
-    interaction_vectors: list[np.array] = field(default_factory=list)
-
-    is_dummy: bool = False
-    is_pseudo_atom: bool = False
-
-
-@dataclass
-class Bond:
-    canon_id: (int, int)
-    index1: int
-    index2: int
-    order: int = DEFAULT_BOND_ORDER
-    rotatable: bool = DEFAULT_BOND_ROTATABLE
-
-    def __init__(
-        self,
-        index1: int,
-        index2: int,
-        order: int = DEFAULT_BOND_ORDER,
-        rotatable: bool = DEFAULT_BOND_ROTATABLE,
-    ):
-        self.canon_id = self.get_bond_id(index1, index2)
-        self.index1 = index1
-        self.index2 = index2
-        self.order = order
-        self.rotatable = rotatable
-        return
-
-    @staticmethod
-    def get_bond_id(idx1: int, idx2: int):
-        """
-        Generates a consistent, "canonical", bond id from a pair of atom indices in the graph.
-
-        Parameters
-        ----------
-        idx1: int
-            atom index of one of the atoms in the bond
-        idx2: int
-            atom index of the other atom in the bond
-
-        Returns
-        -------
-        canon_id: tuple
-            a tuple of the two indices in their canonical order.
-        """
-        idx_min = min(idx1, idx2)
-        idx_max = max(idx1, idx2)
-        return idx_min, idx_max
-
-
-@dataclass
-class Ring:
-    ring_id: int
-    corner_flip: bool = DEFAULT_RING_CORNER_FLIP
-    graph: dict = DEFAULT_RING_GRAPH
-    is_aromatic: bool = DEFAULT_RING_IS_AROMATIC
-
-
-@dataclass
-class Restraint:
-    atom_index: int
-    target_xyz: (float, float, float)
-    kcal_per_angstrom_square: float
-    delay_angstroms: float
-
-    def copy(self):
-        new_target_xyz = (self.target_xyz[0], self.target_xyz[1], self.target_xyz[2])
-        new_restraint = Restraint(
-            self.atom_index,
-            new_target_xyz,
-            self.kcal_per_angstrom_square,
-            self.delay_angstroms,
-        )
-        return new_restraint

--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -69,11 +69,12 @@ class MoleculeSetup:
         a list of indices of pseudo-atoms?
 
     coord: OrderedDict()
-        a mapping between atom index and coordinates
+        a mapping between atom index and coordinates, where atom indices are stored as ints and coordinates are
+        numpy arrays of three floats.
     charge: OrderedDict()
         a mapping between atom index and charge
     pdbinfo: OrderedDict()
-        a mapping between atom index and pdb data for that atom
+        a mapping between atom index (int) and pdb data (PDBAtomInfo) for that atom
     atom_type: OrderedDict()
         TODO: if these values are meant to be consistent, then this should be an enum?
         a mapping from some sort of index (presumably an int) to atom type (string)
@@ -81,7 +82,7 @@ class MoleculeSetup:
         a mapping from the name of a parameter (string) to a parameter
 
     dihedral_interactions: list[]
-        a list of strings I think?
+        a list of strings maybe?
     dihedral_partaking_atoms: dict()
         a mapping from atom index (int?) to dihedral index (int?)
     dihedral_labels: dict()
@@ -1293,6 +1294,7 @@ class UniqAtomParams:
     param_names: list[]
         can be thought of as columns
     """
+
     def __init__(self):
         self.params = []  # aka rows
         self.param_names = []  # aka column names
@@ -1424,3 +1426,40 @@ class Restraint:
             self.kcal_per_angstrom_square,
             self.delay_angstroms)
         return new_restraint
+
+
+# TODO: refactor molsetup class then refactor this and consider making it more readable.
+class MoleculeSetupEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, MoleculeSetup):
+            return {
+                "atom_pseudo": obj.atom_pseudo,
+                "coord": {k: v.tolist() for k, v in obj.coord.items()},
+                "charge": obj.charge,
+                "pdbinfo": obj.pdbinfo,
+                "atom_type": obj.atom_type,
+                "atom_params": obj.atom_params,
+                "dihedral_interactions": obj.dihedral_interactions,
+                "dihedral_partaking_atoms": obj.dihedral_partaking_atoms,
+                "dihedral_labels": obj.dihedral_labels,
+                "atom_ignore": obj.atom_ignore,
+                "chiral": obj.chiral,
+                "atom_true_count": obj.atom_true_count,
+                "graph": obj.graph,
+                "bond": obj.bond,
+                "element": obj.element,
+                "interaction_vector": obj.interaction_vector,
+                "flexibility_model": obj.flexibility_model,
+                "ring_closure_info": obj.ring_closure_info,
+                "restraints": obj.restraints,
+                "is_sidechain": obj.is_sidechain,
+                "rmsd_symmetry_indices": obj.rmsd_symmetry_indices,
+                "rings": obj.rings,
+                "rings_aromatic": obj.rings_aromatic,
+                "atom_to_ring_id": obj.atom_to_ring_id,
+                "ring_corners": obj.ring_corners,
+                "name": obj.name,
+                "rotamers": obj.rotamers
+            }
+            # return obj.__dict__ -> numpy arrays are not json serializable via json dumps
+        return json.JSONEncoder.default(self, obj)

--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -16,6 +16,7 @@ import numpy as np
 import rdkit.Chem
 from rdkit import Chem
 from rdkit.Chem import rdPartialCharges
+from .utils import rdkitutils
 
 # region DEFAULT VALUES
 DEFAULT_PDBINFO = None
@@ -32,6 +33,139 @@ DEFAULT_RING_CORNER_FLIP = False
 DEFAULT_RING_GRAPH = defaultdict
 DEFAULT_RING_IS_AROMATIC = False
 # endregion
+
+
+class UniqAtomParams:
+    """
+    A helper class used to keep parameters organized in a particular way that lets them be more usable.
+
+    Attributes
+    ----------
+    params: list[]
+        can be thought of as rows
+    param_names: list[]
+        can be thought of as columns
+    """
+
+    def __init__(self):
+        self.params = []  # aka rows
+        self.param_names = []  # aka column names
+
+    @classmethod
+    def from_dict(cls, dictionary):
+        """
+        Creates an UniqAtomParams object, populates it with information from the input dictionary, then returns
+        the new object.
+
+        Parameters
+        ----------
+        dictionary: dict()
+            A dictionary containing the keys "params" and "param_names", where the value for "params" is parseable as
+            rows and the value for "param_names" contains the corresponding column data.
+
+        Returns
+        -------
+        A populated UniqAtomParams object
+        """
+        uap = UniqAtomParams()
+        uap.params = [row.copy() for row in dictionary["params"]]
+        uap.param_names = dictionary["param_names"].copy()
+        return uap
+
+    def get_indices_from_atom_params(self, atom_params):
+        """
+        Retrieves the indices of specific atom parameters in the UniqAtomParams object.
+
+        Parameters
+        ----------
+        atom_params: dict()
+            A dict with keys that correspond to the param names already in the UniqAtomParams object. The values are
+            lists that should all be the same size, and
+
+        Returns
+        -------
+        A list of indices corresponding to the order of parameters in the atom_params value lists that indicates the
+        index of that "row" of parameters in UniqAtomParams params.
+        """
+        nr_items = set([len(values) for key, values in atom_params.items()])
+        if len(nr_items) != 1:
+            raise RuntimeError(
+                f"all lists in atom_params must have same length, got {nr_items}"
+            )
+        if set(atom_params) != set(self.param_names):
+            msg = f"parameter names in atom_params differ from internal ones\n"
+            msg += f"  - in atom_params: {set(atom_params)}"
+            msg += f"  - internal: {set(self.param_names)}"
+            raise RuntimeError(msg)
+        nr_items = nr_items.pop()
+        param_idxs = []
+        for i in range(nr_items):
+            row = [atom_params[key][i] for key in self.param_names]
+            param_index = None
+            for j, existing_row in enumerate(self.params):
+                if row == existing_row:
+                    param_index = j
+                    break
+            param_idxs.append(param_index)
+        return param_idxs
+
+    def add_parameter(self, new_param_dict):
+        # remove None values to avoid a column with only Nones
+        new_param_dict = {k: v for k, v in new_param_dict.items() if v is not None}
+        incoming_keys = set(new_param_dict.keys())
+        existing_keys = set(self.param_names)
+        new_keys = incoming_keys.difference(existing_keys)
+        for new_key in new_keys:
+            self.param_names.append(new_key)
+            for row in self.params:
+                row.append(None)  # fill in empty "cell" in new "column"
+
+        new_row = []
+        for key in self.param_names:
+            value = new_param_dict.get(key, None)
+            new_row.append(value)
+
+        if len(new_keys) == 0:  # try to match with existing row
+            for index, row in enumerate(self.params):
+                if row == new_row:
+                    return index
+
+        # if we are here, we didn't match
+        new_row_index = len(self.params)
+        self.params.append(new_row)
+        return new_row_index
+
+    def add_molsetup(
+        self, molsetup, atom_params=None, add_atomic_nr=False, add_atom_type=False
+    ):
+        if "q" in molsetup.atom_params or "atom_type" in molsetup.atom_params:
+            msg = '"q" and "atom_type" found in molsetup.atom_params'
+            msg += " but are hard-coded to store molsetup.charge and"
+            msg += " molsetup.atom_type in the internal data structure"
+            raise RuntimeError(msg)
+        if atom_params is None:
+            atom_params = molsetup.atom_params
+        param_idxs = []
+        for atom_index, ignore in enumerate(molsetup.atom_ignore):
+            if ignore:
+                param_idx = None
+            else:
+                p = {k: v[atom_index] for (k, v) in molsetup.atom_params.items()}
+                if add_atomic_nr:
+                    if "atomic_nr" in p:
+                        raise RuntimeError(
+                            "trying to add atomic_nr but it's already in atom_params"
+                        )
+                    p["atomic_nr"] = molsetup.element[atom_index]
+                if add_atom_type:
+                    if "atom_type" in p:
+                        raise RuntimeError(
+                            "trying to add atom_type but it's already in atom_params"
+                        )
+                    p["atom_type"] = molsetup.atom_type[atom_index]
+                param_idx = self.add_parameter(p)
+            param_idxs.append(param_idx)
+        return param_idxs
 
 
 class MoleculeSetup:
@@ -969,139 +1103,6 @@ class Ring:
     corner_flip: bool = DEFAULT_RING_CORNER_FLIP
     graph: dict = DEFAULT_RING_GRAPH
     is_aromatic: bool = DEFAULT_RING_IS_AROMATIC
-
-
-class UniqAtomParams:
-    """
-    A helper class used to keep parameters organized in a particular way that lets them be more usable.
-
-    Attributes
-    ----------
-    params: list[]
-        can be thought of as rows
-    param_names: list[]
-        can be thought of as columns
-    """
-
-    def __init__(self):
-        self.params = []  # aka rows
-        self.param_names = []  # aka column names
-
-    @classmethod
-    def from_dict(cls, dictionary):
-        """
-        Creates an UniqAtomParams object, populates it with information from the input dictionary, then returns
-        the new object.
-
-        Parameters
-        ----------
-        dictionary: dict()
-            A dictionary containing the keys "params" and "param_names", where the value for "params" is parseable as
-            rows and the value for "param_names" contains the corresponding column data.
-
-        Returns
-        -------
-        A populated UniqAtomParams object
-        """
-        uap = UniqAtomParams()
-        uap.params = [row.copy() for row in dictionary["params"]]
-        uap.param_names = dictionary["param_names"].copy()
-        return uap
-
-    def get_indices_from_atom_params(self, atom_params):
-        """
-        Retrieves the indices of specific atom parameters in the UniqAtomParams object.
-
-        Parameters
-        ----------
-        atom_params: dict()
-            A dict with keys that correspond to the param names already in the UniqAtomParams object. The values are
-            lists that should all be the same size, and
-
-        Returns
-        -------
-        A list of indices corresponding to the order of parameters in the atom_params value lists that indicates the
-        index of that "row" of parameters in UniqAtomParams params.
-        """
-        nr_items = set([len(values) for key, values in atom_params.items()])
-        if len(nr_items) != 1:
-            raise RuntimeError(
-                f"all lists in atom_params must have same length, got {nr_items}"
-            )
-        if set(atom_params) != set(self.param_names):
-            msg = f"parameter names in atom_params differ from internal ones\n"
-            msg += f"  - in atom_params: {set(atom_params)}"
-            msg += f"  - internal: {set(self.param_names)}"
-            raise RuntimeError(msg)
-        nr_items = nr_items.pop()
-        param_idxs = []
-        for i in range(nr_items):
-            row = [atom_params[key][i] for key in self.param_names]
-            param_index = None
-            for j, existing_row in enumerate(self.params):
-                if row == existing_row:
-                    param_index = j
-                    break
-            param_idxs.append(param_index)
-        return param_idxs
-
-    def add_parameter(self, new_param_dict):
-        # remove None values to avoid a column with only Nones
-        new_param_dict = {k: v for k, v in new_param_dict.items() if v is not None}
-        incoming_keys = set(new_param_dict.keys())
-        existing_keys = set(self.param_names)
-        new_keys = incoming_keys.difference(existing_keys)
-        for new_key in new_keys:
-            self.param_names.append(new_key)
-            for row in self.params:
-                row.append(None)  # fill in empty "cell" in new "column"
-
-        new_row = []
-        for key in self.param_names:
-            value = new_param_dict.get(key, None)
-            new_row.append(value)
-
-        if len(new_keys) == 0:  # try to match with existing row
-            for index, row in enumerate(self.params):
-                if row == new_row:
-                    return index
-
-        # if we are here, we didn't match
-        new_row_index = len(self.params)
-        self.params.append(new_row)
-        return new_row_index
-
-    def add_molsetup(
-        self, molsetup, atom_params=None, add_atomic_nr=False, add_atom_type=False
-    ):
-        if "q" in molsetup.atom_params or "atom_type" in molsetup.atom_params:
-            msg = '"q" and "atom_type" found in molsetup.atom_params'
-            msg += " but are hard-coded to store molsetup.charge and"
-            msg += " molsetup.atom_type in the internal data structure"
-            raise RuntimeError(msg)
-        if atom_params is None:
-            atom_params = molsetup.atom_params
-        param_idxs = []
-        for atom_index, ignore in enumerate(molsetup.atom_ignore):
-            if ignore:
-                param_idx = None
-            else:
-                p = {k: v[atom_index] for (k, v) in molsetup.atom_params.items()}
-                if add_atomic_nr:
-                    if "atomic_nr" in p:
-                        raise RuntimeError(
-                            "trying to add atomic_nr but it's already in atom_params"
-                        )
-                    p["atomic_nr"] = molsetup.element[atom_index]
-                if add_atom_type:
-                    if "atom_type" in p:
-                        raise RuntimeError(
-                            "trying to add atom_type but it's already in atom_params"
-                        )
-                    p["atom_type"] = molsetup.atom_type[atom_index]
-                param_idx = self.add_parameter(p)
-            param_idxs.append(param_idx)
-        return param_idxs
 
 
 @dataclass

--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -4,920 +4,441 @@
 # Meeko
 #
 
+from abc import ABC, abstractmethod
 from copy import deepcopy
-from collections import defaultdict, OrderedDict
-from dataclasses import asdict, dataclass
+from collections import defaultdict
+from dataclasses import dataclass
 import json
 import sys
 import warnings
 
 import numpy as np
+import rdkit.Chem
 from rdkit import Chem
 from rdkit.Chem import rdPartialCharges
-from rdkit.Chem import rdMolInterchange
 
-import meeko
-from .utils import rdkitutils
-from .utils import utils
-from .utils.geomutils import calcDihedral
-from .utils.pdbutils import PDBAtomInfo
-from .receptor_pdbqt import PDBQTReceptor
+# region DEFAULT VALUES
+DEFAULT_PDBINFO = None
+DEFAULT_CHARGE = 0.0
+DEFAULT_ELEMENT = None
+DEFAULT_ATOM_TYPE = None
+DEFAULT_IS_IGNORE = False
+DEFAULT_IS_CHIRAL = False
+DEFAULT_GRAPH = field(default_factory=list)
+DEFAULT_INTERACTION_VECTORS = field(default_factory=list)
 
-try:
-    from openbabel import openbabel as ob
-    from .utils import obutils
-except ImportError:
-    _has_openbabel = False
-else:
-    _has_openbabel = True
+DEFAULT_BOND_ORDER = 0
+DEFAULT_BOND_ROTATABLE = False
 
-try:
-    from misctools import StereoIsomorphism
-except ImportError as _import_misctools_error:
-    _has_misctools = False
-else:
-    _has_misctools = True
+DEFAULT_RING_CORNER_FLIP = False
+DEFAULT_RING_GRAPH = defaultdict
+DEFAULT_RING_IS_AROMATIC = False
+# endregion
 
 
 class MoleculeSetup:
-    """
-    Base molecule setup class. Provides a way to store data about molecules and a SMARTS matcher for all atom types.
 
-    Attributes
-    ----------
-    mol: rdkit.Chem.rdchem.Mol
-        should only be an attribute in the RDKitMoleculeSetup subclass, but it is possible that it could get assigned
-        in a regular MoleculeSetup
-    atom_pseudo: List[]
-        a list of indices of pseudo-atoms
+    # region CLASS CONSTANTS
+    PSEUDOATOM_ELEMENT = 0
+    # endregion
 
-    coord: OrderedDict()
-        a mapping between atom index and coordinates, where atom indices are stored as ints and coordinates are
-        numpy arrays of three floats.
-    charge: OrderedDict()
-        a mapping between atom index (int) and charge (float)
-    pdbinfo: list[]
-        a mapping between atom index (int) and pdb data (PDBAtomInfo) for that atom
-    atom_type: OrderedDict()
-        a mapping from atom index (int) to atom type (string)
-    atom_params: dict()
-        a mapping from the name of a parameter (string) to a parameter
+    def __init__(self, name: str = None, is_sidechain: bool = False):
+        # Molecule Setup Identity
+        self.name = name
+        self.is_sidechain = is_sidechain
+        self.true_atom_count = 0
+        self.pseudo_atom_count = 0
 
-    dihedral_interactions: list[]
-        a list of strings maybe?
-    dihedral_partaking_atoms: dict()
-        a mapping from atom index (int?) to dihedral index (int?)
-    dihedral_labels: dict()
-        a mapping from atom index to a string dihedral label
-
-    atom_ignore: OrderedDict()
-        a mapping from atom index to the bool that indicates whether it should be ignored
-    chiral: OrderedDict()
-        a mapping from atom index to a bool that indicates whether an atom is chiral
-    atom_true_count: int
-        the number of atoms being represented in this molsetup
-    graph: OrderedDict()
-        a mapping from atom index (int) to a list of neighboring atom indices?
-    bond: OrderedDict()
-        a mapping from bond id (tuple of ints) to a dictionary containing two elements. The elements are
-        bond_order (int) and rotatable (bool).
-    element: OrderedDict()
-        represents the atomic number of the atom index. A mapping from atom index to atomic number
-    interaction_vector: OrderedDict()
-        a mapping from atom index to a list representing directional interaction vectors for atom idx
-    flexibility_model: dict()
-        unclear what exactly is consistently contained by this dict, but it seems to be a keyword to value dictionary
-    ring_closure_info: dict() containing two elements.
-        desperately in need of refactoring.
-    restraints: list[]
-        list of restraint dataclasses
-    is_sidechain: bool
-        indicates whether this molsetup pertains to a sidechain
-    rmsd_symmetry_indices: empty tuple
-        only seems to be set in RDKit version of molsetup, at which point it set to be equal to tuples of the indices
-        of the molecule's atoms that match a substructure query.
-
-    rings: dict()
-        store information about rings, like if they have corners that can be flipped and the graph of atoms that belong
-        to them. Mapping from ring id (string?) to a dictionary with two elements:
-            'corner_flip': bool
-            'graph': dict()
-    rings_aromatic: list[]
-        contains the list of ring_id items that are aromatic
-    atom_to_ring_id: dict()
-        mapping of atom index to ring id of each atom belonging to the ring
-    ring_corners: dict()
-        unclear what this is a mapping of, but is used to store corner flexibility for the rings
-
-    name: string or None
-        should this be here or does it only need to be in the RDKit version of this class.
-        either contains the name of the molecule as provided in RDKit or is None.
-    rotamers: list[]
-        A list of rotamers, where each rotamer is represented as a dictionary mapping from bond_id (presumably a string
-        or an int) to an int or a float representing something
-    """
-
-    def __init__(self):
-        # Simple attributes defining core properties of the molecule setup
-        self.atom_true_count = 0
-        self.is_sidechain = False
-        self.name = None
-
-        # Internal lists and keyword dicts.
-        self.atom_pseudo = [] # List of pseudoatom indices
-        self.atom_params = {}
-        self.restraints = []
-        self.rotamers = []
-
-        # Attributes mapping an index of an atom to a property of that atom.
-        self.pdbinfo = []
-        self.coord = []
-        self.charge = []
-        self.element = []
-        self.atom_type = []
-        self.atom_ignore = []
-        self.chiral = []
-        self.graph = []
-        self.interaction_vector = []
-
-        # Matching bond id to bond information
-        self.bond = {}
-
-        # Dihedral information
-        self.dihedral_interactions = []
-        self.dihedral_partaking_atoms = {}
-        self.dihedral_labels = {}
-
-        # Dictionaries needing some sort of cleanup or clarification
-        self.flexibility_model = {}
-        self.ring_closure_info = {
-            "bonds_removed": [],
-            "pseudos_by_atom": {},
-        }
-
-        # Ring attributes
+        # Tracking atoms and bonds
+        self.atoms: list[Atom] = []
+        self.bond_info = {}
         self.rings = {}
-        self.rings_aromatic = []
-        self.atom_to_ring_id = defaultdict(list)
-        self.ring_corners = {}  # used to store corner flexibility
+        self.rotamers = []
+        pass
 
     @classmethod
-    def from_prmtop_inpcrd(cls, prmtop, crd_filename):
+    def from_prmtop_inpcrd(cls, prmtop, crd_filename: str):
+        # TODO: pull functionality over and clean up
+        pass
+
+    # region Manually Building A MoleculeSetup
+    def add_atom(
+        self,
+        atom_index: int = None,
+        overwrite: bool = False,
+        pdbinfo: string = DEFAULT_PDBINFO,
+        charge: float = DEFAULT_CHARGE,
+        element: int = DEFAULT_ELEMENT,
+        atom_type: str = DEFAULT_TYPE,
+        is_ignore: bool = DEFAULT_IS_IGNORE,
+        is_chiral: bool = DEFAULT_IS_CHIRAL,
+        graph: list[int] = DEFAULT_GRAPH,
+    ):
         """
-        Creates a MoleculeSetup object populated using input data in a format specifically from Amber molecular
-        dynamics software.
+        Adds an atom with all the specified attributes to the MoleculeSetup, either at the specified atom index, or by
+        appending it to the internal list of atoms. Default values will be used for any attributes with unspecified
+        values.
 
         Parameters
         ----------
-        prmtop:
-        crd_filename: string
-
-        Returns
-        -------
-        A MoleculeSetup instance populated with data from the input prmtop and crd file.
-        """
-        # Constants used while converting file contents to MoleculeSetup fields:
-        amber_charge_conversion_factor = 18.2223
-        # Creates a MoleculeSetup instance.
-        molsetup = cls()
-        # Gets coordinates from the input files
-        x, y, z = prmtop._coords_from_inpcrd(crd_filename)
-        # Checks for inconsistency in the input data
-        all_atom_indices = prmtop.vmdsel("")
-        if len(all_atom_indices) != len(x):
-            raise RuntimeError("number of prmtop atoms differs from x coordinates")
-        # Pulling data from the input files
-        prmtop.upper_atom_types = prmtop._gen_gaff_uppercase()
-        charges = [chrg / amber_charge_conversion_factor for chrg in prmtop.read_flag("CHARGE")]
-        atomic_nrs = prmtop.read_flag("ATOMIC_NUMBER")
-        # Setting up space in atom parameters dict.
-        molsetup.atom_params["rmin_half"] = []
-        molsetup.atom_params["epsilon"] = []
-        vdw_by_atype = {}
-        for vdw in prmtop._retrieve_vdw():
-            if vdw.atom in vdw_by_atype:
-                raise RuntimeError("repeated atom type from prmtop._retrieve_vdw()")
-            vdw_by_atype[vdw.atom] = {"rmin_half": vdw.r, "epsilon": vdw.e}
-        for i in prmtop.atom_sel_idx:
-            pdbinfo = rdkitutils.PDBAtomInfo(
-                name=prmtop.pdb_atom_name[i],
-                resName=prmtop.pdb_resname[i],
-                resNum=int(prmtop.pdb_resid[i]),
-                chain=" ",
-            )
-            atype = prmtop.upper_atom_types[i]
-            molsetup.add_atom(
-                i,
-                coord=(x[i], y[i], z[i]),
-                charge=charges[i],
-                atom_type=atype,
-                element=atomic_nrs[i],
-                pdbinfo=pdbinfo,
-                chiral=False,
-                ignore=False,
-                add_atom_params={
-                    "rmin_half": vdw_by_atype[atype]["rmin_half"],
-                    "epsilon": vdw_by_atype[atype]["epsilon"],
-                }
-            )
-            # molsetup.atom_params["rmin_half"].append(vdw_by_atype[atype]["rmin_half"])
-            # molsetup.atom_params["epsilon"].append(vdw_by_atype[atype]["epsilon"])
-        bond_order = 1  # the prmtop does not have bond orders, so we set all to 1
-        bonds_inc_h = prmtop.read_flag("BONDS_INC_HYDROGEN")
-        bonds_not_h = prmtop.read_flag("BONDS_WITHOUT_HYDROGEN")
-        bonds = bonds_inc_h + bonds_not_h
-        nr_bonds = int(len(bonds) / 3)
-        for index_bond in range(nr_bonds):
-            i_atom = int(bonds[index_bond * 3 + 0] / 3)
-            j_atom = int(bonds[index_bond * 3 + 1] / 3)
-            if (i_atom in prmtop.atom_sel_idx) and (j_atom in prmtop.atom_sel_idx):
-                molsetup.add_bond(i_atom, j_atom, order=bond_order, rotatable=False)
-        return molsetup
-
-    # region Adding and Removing Molecule Components
-    def add_atom(self, idx=None, coord=np.array([0.0, 0.0, 0.0], dtype='float'),
-                 element=None, charge=0.0, atom_type=None, pdbinfo=None,
-                 ignore=False, chiral=False, overwrite=False, add_atom_params=None):
-        """
-        Adds an atom with all of the atom information a user wants to specify to the molsetup. Every property is
-        optional, but possible to set. Properties that are not specified by the user are set to a default value.
-
-        Parameters
-        ----------
-        idx: int or None
-            atom index
-        coord: np float array of length 3
-            coordinates indicating the atom's location
-        element: int or None
-            the atomic number of the atom
-        charge: float
-            partial charges to be loaded for the atom
-        atom_type: string or None
-            needs info
-        pdbinfo: string or None:
-            pdb string for the atom
-        ignore: bool
-            ignore flag for the atom
-        chiral: bool
-            chiral flag for the atom
+        atom_index: int
         overwrite: bool
-            are we overwriting other atoms that may be in the same coordinate position as this one
-        add_atom_params: dict or None
-            needs info
+        pdbinfo: str
+        charge: float
+        element: int
+        atom_type: str
+        is_ignore: bool
+        is_chiral: bool
+        graph: List[List[int]]
 
         Returns
         -------
-        idx: int
-            False if the index is already occupied and we are not overwriting existing atoms. If the method succeeds,
-            returns the index of the added atom.
+        None
+
+        Raises
+        ------
+        RuntimeException
+            If the user tries to overwrite an existing atom without explicitly allowing overwrites.
         """
-        # reads in atom_params if a dictionary of atom_params has been provided
-        for key in self.atom_params:
-            if type(add_atom_params) is dict and key in add_atom_params:
-                value = add_atom_params[key]
-            else:
-                value = None
-            self.atom_params[key].append(value)
+        # If atom index is specified and it would be trying to overwrite an existing atom in the atom list, raises a
+        # Runtime Exception
+        insert_disallowed = len(self.atoms) > atom_index and not overwrite
+        dummy_atom_present = self.atoms[atom_index].is_dummy
+        if atom_index is not None and insert_disallowed and not dummy_atom_present:
+            raise RuntimeError(
+                "ADD_ATOM Error: the atom_index [%d] is already occupied (use 'overwrite' to force)"
+            )
 
-        # If atom index is specified checks if we want to insert and overwrite values
-        if idx is not None:
-            # If the specified index already exists, checks that we have permission to overwrite it.
-            if len(self.coord) > idx:
-                if overwrite:
-                    self.pdbinfo[idx] = pdbinfo
-                    self.coord[idx] = coord
-                    self.charge[idx] = charge
-                    self.element[idx] = element
-                    self.atom_type[idx] = atom_type
-                    self.atom_ignore[idx] = ignore
-                    self.chiral[idx] = chiral
-                    self.graph[idx] = []
-                    return idx
-                else:
-                    print("ADD_ATOM Error: the idx [%d] is already occupied (use 'overwrite' to force)")
-                    return False
-            # If the specified index is much greater than self.coord, then extends all lists with None values
-            # until we can append the given index.
-            while idx > len(self.coord):
-                self.pdbinfo.append(None)
-                self.coord.append(np.array([0.0, 0.0, 0.0], dtype='float'))
-                self.charge.append(0.0)
-                self.element.append(None)
-                self.atom_type.append(None)
-                self.atom_ignore.append(False)
-                self.chiral.append(False)
-                self.graph.append([])
+        # If atom index is not specified, appends the new atom to the end of the current atom list
+        if atom_index is None:
+            atom_index = len(self.atoms)
 
-        # Otherwise just appends the information to the end of the list.
-        self.pdbinfo.append(pdbinfo)
-        self.coord.append(coord)
-        self.charge.append(charge)
-        self.element.append(element)
-        self.atom_type.append(atom_type)
-        self.atom_ignore.append(ignore)
-        self.chiral.append(chiral)
-        self.graph.append([])
+        # Inserts dummy atoms if a specified atom index is greater than the current length of the atom list
+        while atom_index > len(self.atoms):
+            self.atoms.append(Atom(len(self.atoms), is_dummy=True))
 
-        return idx
+        # Creates and adds new atom to the atom list
+        new_atom = Atom(
+            atom_index, pdbinfo, charge, element, atom_type, is_ignore, is_chiral, graph
+        )
+        if atom_index < len(self.atoms):
+            atoms[atom_index] = new_atom
+            return
+        self.atoms.append(new_atom)
+        return
 
-    # pseudo-atoms
-    def add_pseudo_atom(self, coord=np.array([0.0, 0.0, 0.0], dtype='float'), charge=0.0,
-                        anchor_list=None, atom_type=None, rotatable=False,
-                        pdbinfo=None, directional_vectors=None, ignore=False, overwrite=False):
+    def add_pseudo_atom(
+        self,
+        pdbinfo: str = DEFAULT_PDBINFO,
+        charge: float = DEFAULT_CHARGE,
+        atom_type: str = DEFAULT_ATOM_TYPE,
+        is_ignore: bool = DEFAULT_IS_IGNORE,
+        anchor_list: list[int] = None,
+        rotatable: bool = False,
+        directional_vectors: list[int] = None,
+    ):
         """
-        Adds a new pseudoatom to the molsetup. Multiple bonds can be specified in "anchor_list" to support the
-        centroids of aromatic rings. If rotatable, makes the anchor atom rotatable to allow the pseudoatom movement
 
         Parameters
         ----------
-        coord: numpy float array of length 3
-            pseudoatom coordinates
-        charge: float
-            partial charge for the pseudoatom
-        anchor_list: list[] or None
-            a list of ints indicating multiple bonds that can be specified
-        atom_type: or None
-        rotatable: bool
-        pdbinfo: string or None
-        directional_vectors: or None
-        ignore: bool
-        overwrite: bool
-            indicates whether the pseudo atom can overwrite atoms at a particular atom index
+        pdbinfo
+        charge
+        atom_type
+        is_ignore
+        anchor_list
+        rotatable
+        directional_vectors
+
         Returns
         -------
 
         """
-        # If there is no specified input atom index, will append the atom to the "end" of the atom lists
-        idx = self.atom_true_count + len(self.atom_pseudo)
-        # Otherwise checks that the specified atom index is not already occupied. If it is, and overwrite is not
-        # specified, will throw an error.
-        if len(self.coord) > idx and not overwrite:
-            print("ADD_PSEUDO> Error: the idx [%d] is already occupied (use 'overwrite' to force)")
-            return False
-        # Adds the atom index to the list of pseudoatom indices so we can track that it is a pseudoatom
-        self.atom_pseudo.append(idx)
-        # Adds the pseudoatom as if it were a regular atom
-        self.add_atom(idx=idx, coord=coord,
-                      element=0,
-                      charge=charge,
-                      atom_type=atom_type,
-                      pdbinfo=pdbinfo,
-                      ignore=ignore,
-                      overwrite=overwrite)
-        # Adds anchor atoms
+        # Places the atom at the end of the atom list.
+        pseudoatom_index = len(self.atoms)
+        # Creates the atom and marks it as a pseudoatom
+        new_pseudoatom = Atom(
+            pseudoatom_index,
+            pdbinfo=pdbinfo,
+            charge=charge,
+            element=PSEUDOATOM_ELEMENT,
+            atom_type=atom_type,
+            is_ignore=is_ignore,
+            is_pseudo_atom=True,
+        )
+        # Adds bonds for all of the provided anchor atoms
         if anchor_list is not None:
             for anchor in anchor_list:
-                self.add_bond(idx, anchor, order=0, rotatable=rotatable)
-        # Adds directional vectors
+                self.add_bond(pseudoatom_index, anchor, rotatable=rotatable)
+        # Adds directional vectors [Check what this is used for/if this is used]
         if directional_vectors is not None:
-            self._add_interaction_vector(idx, directional_vectors)
-        return idx
+            self._add_interaction_vectors(pseudoatom_index, directional_vectors)
+        return pseudoatom_index
 
-    def add_bond(self, idx1, idx2, order=0, rotatable=False):
+    def delete_atom(self, atom_index: int):
         """
-        Adds a bond to the molsetup graph between the two input indices.
+        Clears the atom data at a specified atom index and replaces the atom with a dummy atom.
 
         Parameters
         ----------
-        idx1: int
-            first atom's index
-        idx2: int
-            second atom's index
-        order: int
-            bond order
-        rotatable: bool
-            whether the bond is rotatable
-        """
-        # Checks that the bond is represented in the graph property
-        if idx2 not in self.graph[idx1]:
-            self.graph[idx1].append(idx2)
-        if idx1 not in self.graph[idx2]:
-            self.graph[idx2].append(idx1)
-        # Gets the canonical bond id and ads the bond infommration to the bond dictionary.
-        bond_id = self.get_bond_id(idx1, idx2)
-        self.bond[bond_id] = {
-            'bond_order': order,
-            'rotatable': rotatable,
-        }
-        self.set_bond(idx1, idx2, order, rotatable)
-
-    def get_bond(self, idx1, idx2):
-        """
-        Returns all the properties of a bond if one exists between the two atoms in the
-        Parameters
-        ----------
-        idx1: int
-            atom index of one of the atoms in the bond
-        idx2: int
-            atom index of the other atom in the bond
-
-        Returns
-        -------
-        bond_information: dict
-            A dictionary containing two elements, the bond order and whether the bond is rotatable,
-        """
-        bond_idx = self.get_bond_id(idx1, idx2)
-        try:
-            return self.bond[bond_idx]
-        except IndexError:
-            return None
-
-    def del_bond(self, idx1, idx2):
-        """
-        Given two atom indices, removes information about the bond between them from the bond attribute.
-        Parameters
-        ----------
-        idx1: int
-            atom index of one of the atoms in the bond
-        idx2: int
-            atom index of the other atom in the bond
+        atom_index: int
+            atom index to replace with a dummy atom
 
         Returns
         -------
         None
         """
-        bond_id = self.get_bond_id(idx1, idx2)
-        del self.bond[bond_id]
-        self.graph[idx1].remove(idx2)
-        if not self.graph[idx1]:
-            del self.graph[idx1]
-        self.graph[idx2].remove(idx1)
-        if not self.graph[idx2]:
-            del self.graph[idx2]
+        blank_atom = Atom(atom_index, is_dummy=True)
+        self.atoms[atom_index] = blank_atom
+        return
 
-    @staticmethod
-    def get_bond_id(idx1, idx2):
+    def add_bond(
+        self,
+        atom_index_1: int,
+        atom_index_2: int,
+        order: int = DEFAULT_BOND_ORDER,
+        rotatable: bool = DEFAULT_BOND_ROTABLE,
+    ):
         """
-        Generates a consistent, "canonical", bond id from a pair of atoms in the graph.
 
         Parameters
         ----------
-        idx1: int
-            atom index of one of the atoms in the bond
-        idx2: int
-            atom index of the other atom in the bond
+        atom_index_1
+        atom_index_2
+        order
+        rotatable
 
         Returns
         -------
-        canon_id: tuple
-            a tuple of the two indices in their canonical order.
+
+        Raises
+        ------
+
         """
-        idx_min = min(idx1, idx2)
-        idx_max = max(idx1, idx2)
-        return idx_min, idx_max
+        # Checks that both of the atom indices provided are valid indices, otherwise throws an error
+        if len(self.atoms) <= atom_index_1 or len(self.atoms) <= atom_index_2:
+            raise IndexError(
+                "ADD_BOND: provided atom indices outside the range of atoms currently in MoleculeSetup"
+            )
+        # Adds each atom to the other's bond graph
+        if atom_index_2 not in self.atoms[atom_index_1].graph:
+            self.atoms[atom_index_1].graph.append(atom_index_2)
+        if atom_index_1 not in self.atoms[atom_index_2].graph:
+            self.atoms[atom_index_2].graph.append(atom_index_1)
+        # Creates new bond object and uses its internal canonical bond id to add it to MoleculeSetup bond tracking.
+        new_bond = Bond(atom_index_1, atom_index_2, order, rotatable)
+        self.bond_info[new_bond.canon_id] = new_bond
+        return
 
-        # replaced by
+    def delete_bond(self, atom_index_1: int, atom_index_2: int):
+        """
 
-    def add_rotamer(self, indices_list, angles_list):
-        xyz = self.coord
-        rotamer = {}
-        for (i1, i2, i3, i4), angle in zip(indices_list, angles_list):
-            bond_id = self.get_bond_id(i2, i3)
-            if bond_id in rotamer:
-                raise RuntimeError("repeated bond %d-%d" % bond_id)
-            if not self.bond[bond_id]["rotatable"]:
-                raise RuntimeError("trying to add rotamer for non rotatable bond %d-%d" % bond_id)
-            d0 = calcDihedral(xyz[i1], xyz[i2], xyz[i3], xyz[i4])
-            rotamer[bond_id] = angle - d0
-        self.rotamers.append(rotamer)
+        Parameters
+        ----------
+        atom_index_1
+        atom_index_2
+
+        Returns
+        -------
+
+        """
+        # Gets canon bond id for the bond to delete
+        canon_bond_id = Bond.get_bond_id(atom_index_1, atom_index_2)
+        # Deletes the bond from the internal bond table
+        del self.bond_info[canon_bond_id]
+        # Removes the bond from each atom's graph
+        self.atoms[atom_index_1].graph.remove(atom_index_2)
+        self.atoms[atom_index_2].graph.remove(atom_index_1)
+        return
+
+    def add_rotamers(
+        self, index_list: list[(int, int, int, int)], angles_list: np.ndarray
+    ):
+        # TODO: pull implementation over
+        pass
+
+    def count_true_atoms(self):
+        for atom in self.atoms:
+            if not atom.is_pseudo_atom and not atom.is_dummy:
+                self.true_atom_count += 1
+        return
+
+    def _add_interaction_vectors(self, atom_index: int, vector_list: list[np.array]):
+        """
+        Adds input vector list to the list of directional ineraction vectors for the specified atom.
+
+        Parameters
+        ----------
+        atom_index: int
+            index of the atom to add the vectors to
+        vector_list: list[np.array]
+            a list of directional interaction vectors
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        IndexError
+            if the specified atom index does not exist or is a dummy atom.
+        """
+        if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
+            raise IndexError(
+                "INTERACTION_VECTORS: provided atom index is out of range or is a dummy atom"
+            )
+        for vector in vector_list:
+            self.atoms[atom_index].interaction_vectors.append(vector)
+        return
 
     # endregion
 
-    # region Original Getters and Setters
-    # Especially as many of these pertain to data structures that will be changed, we should consider the necessity of
-    # having so many basic getters and setters in a python class, especially since we haven't limited access to the
-    # original attributes. These are under strong consideration for deprecation.
+    # region Getters and Setters
 
-    # pdbinfo
-    def get_pdbinfo(self, idx):
+    def get_pdbinfo(self, atom_index: int):
+        if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
+            raise IndexError(
+                "GET_PDBINFO: provided atom index is out of range or is a dummy atom"
+            )
+        return self.atoms[atom_index].pdbinfo
+
+    def get_charge(self, atom_index: int):
+        if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
+            raise IndexError(
+                "GET_CHARGE: provided atom index is out of range or is a dummy atom"
+            )
+        return self.atoms[atom_index].charge
+
+    def get_element(self, atom_index: int):
+        if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
+            raise IndexError(
+                "GET_ELEMENT: provided atom index is out of range or is a dummy atom"
+            )
+        return self.atoms[atom_index].element
+
+    def get_atom_type(self, atom_index: int):
+        if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
+            raise IndexError(
+                "GET_ATOM_TYPE: provided atom index is out of range or is a dummy atom"
+            )
+        return self.atoms[atom_index].atom_type
+
+    def set_atom_type_from_uniq_atom_params(
+        self, uniq_atom_params: UniqAtomParams, prefix: str
+    ):
         """
-        Gets the pdb information corresponding to a particular atom index.
-        Parameters
-        ----------
-        idx: int
-            atom index to retrieve pdb info for.
-
-        Returns
-        -------
-        pdbinfo: str
-            a string of pdb data corresponding to the given atom index.
-        """
-        return self.pdbinfo[idx]
-
-    # coordinates
-    def set_coord(self, idx, coord):
-        """
-        Manually sets the coordinates at a particular atom index.
-        Parameters
-        ----------
-        idx: int
-            atom index to set the coordinates
-        coord: numpy array with 3 floats
-            desired coordinates value to set
-
-        Returns
-        -------
-        None
-        """
-        self.coord[idx] = coord
-
-    def get_coord(self, idx):
-        """
-        Returns coordinates at a particular atom index
-
-        Parameters
-        ----------
-        idx: int
-            atom index to retrieve coordinates for
-
-        Returns
-        -------
-        coord: numpy array with 3 floats
-            A numpy array with three floats representing the coordinates
-        """
-        return self.coord[idx]
-
-    # element
-    def set_element(self, idx, elem_num):
-        """
-        Sets the atomic number for an element at a particular atom index.
-
-        Parameters
-        ----------
-        idx: int
-            atom index to set atomic number for
-        elem_num: int
-            atomic number for the atom in question
-
-        Returns
-        -------
-        None
-        """
-        self.element[idx] = elem_num
-
-    def get_element(self, idx):
-        """
-        Gets the atomic number for the element at a particular atom index.
-        Parameters
-        ----------
-        idx: int
-            atom index to retrieve element information for.
-
-        Returns
-        -------
-        element: int
-            atomic number of the element at the specified atom index
-        """
-        return self.element[idx]
-
-    # partial charge
-    def set_charge(self, idx, charge):
-        """
-        Sets partial charge for a particular atom index.
-        Parameters
-        ----------
-        idx: int
-            atom index to set the charge
-        charge: float
-            partial charge to set the
-
-        Returns
-        -------
-
-        """
-        self.charge[idx] = charge
-
-    def get_charge(self, idx):
-        """
-        Returns partial charges for a particular atom index.
-
-        Parameters
-        ----------
-        idx: int
-            atom index to retrieve partial charge for
-
-        Returns
-        -------
-        charge: float
-            partial charge for the particular atom index
-        """
-        return self.charge[idx]
-
-    # atom_type
-    def set_atom_type(self, idx, atom_type):
-        """
-        Sets atom type for a specified atom index.
-
-        Parameters
-        ----------
-        idx: int
-            atom index to modify
-        atom_type: str
-            desired atom type
-        Returns
-        -------
-        None
-        """
-        self.atom_type[idx] = atom_type
-
-    def set_atom_types_from_uniq_atom_params(self, uniq_atom_params, prefix):
-        """
-        Uses a UniqAtomParams object to set the atom_type attribute in the molsetup object. Adds the specified prefix
-        to each of the atom types.
+        Uses a UniqAtomParams object to set the atom_type attribute for atoms in the Molecule Setup object. Adds the specified prefix
+        to each of the atom_type attributes pulled from UniqAtomParams.
 
         Parameters
         ----------
         uniq_atom_params: UniqAtomParams
-            A uniq atom params object to extract the atom_types from
+            A uniq atom params object to extract atom_type from
         prefix: string
-            A prefix to be appended to all the atom_types.
+            A prefix to be appended to all the atom_type attributes
 
         Returns
         -------
         None
         """
         # Gets a mapping from parameter indices in atom_params to those in uniq_atom_params
-        parameter_indices = uniq_atom_params.get_indices_from_atom_params(self.atom_params)
+        parameter_indices = uniq_atom_params.get_indices_from_atom_params(
+            self.atom_params
+        )
         # Checks that we have the correct number of retrieved indices.
-        if len(parameter_indices) != len(self.atom_type):
-            raise RuntimeError("{len(parameter_indices)} parameters but {len(self.atom_type)} in molsetup")
+        if len(parameter_indices) != len(self.atoms):
+            raise RuntimeError(
+                "Number of parameters ({len(parameter_indices)}) not equal to number of atoms in Molecule Setup ({len(self.atom_type)})"
+            )
         # Loops through the indices in parameter indices and sets atom types with the input prefix
         for i, j in enumerate(parameter_indices):
             self.atom_type[i] = f"{prefix}{j}"
         return None
 
-    def get_atom_type(self, idx):
-        """
-        Returns the atom type for a specific atom index.
+    def get_is_ignore(self, atom_index: int):
+        if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
+            raise IndexError(
+                "GET_IS_IGNORE: provided atom index is out of range or is a dummy atom"
+            )
+        return self.atoms[atom_index].is_ignore
 
-        Parameters
-        ----------
-        idx: int
-            atom index to retrieve data for
+    def get_is_chiral(self, atom_index: int):
+        if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
+            raise IndexError(
+                "GET_IS_CHIRAL: provided atom index is out of range or is a dummy atom"
+            )
+        return self.atoms[atom_index].is_chiral
 
-        Returns
-        -------
-        atom_type: str
-            the atom type present at a particular atom index
+    def get_neighbors(self, atom_index: int):
+        if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
+            raise IndexError(
+                "GET_GRAPH: provided atom index is out of range or is a dummy atom"
+            )
+        return self.atoms[atom_index].graph
 
-        """
-        return self.atom_type[idx]
-
-    # atom_ignore
-    def set_ignore(self, idx: int, state: bool):
-        """
-        Sets the ignore flag for a specified atom index.
-
-        Parameters
-        ----------
-        idx: int
-            atom index to set the ignore flag for
-        state: bool
-            ignore flag value to be set
-
-        Returns
-        -------
-        None
-        """
-        self.atom_ignore[idx] = state
-
-    def get_ignore(self, idx: int):
-        """
-        Returns atom_ignore flag value for a particular atom index.
-
-        Parameters
-        ----------
-        idx: int
-
-        Returns
-        -------
-        atom_ignore: bool
-            a boolean indicating the value of the ignore flag for this atom index
-        """
-        """ return if the atom is ignored"""
-        return bool(self.atom_ignore[idx])
-
-    # chiral
-    def set_chiral(self, idx, chiral):
-        """
-        Sets the chiral flag for a given atom index.
-
-        Parameters
-        ----------
-        idx: int
-            atom index
-        chiral:
-            desired chiral flag value
-
-        Returns
-        -------
-        None
-        """
-        self.chiral[idx] = chiral
-
-    def get_chiral(self, idx):
-        """
-        Retrieves chiral flag value for a given atom index.
-
-        Parameters
-        ----------
-        idx: int
-            atom index to retrieve chiral flag value for
-
-        Returns
-        -------
-        chiral: bool
-            The value of the chiral flag for the input atom index.
-        """
-        return self.chiral[idx]
-
-    # graph
-    def get_neighbors(self, idx):
-        """
-        Gets the graph values for a particular atom index, which should show the atom's neighbors.
-
-        Parameters
-        ----------
-        idx: int
-            atom index to check graph values for
-
-        Returns
-        -------
-        graph_list: list
-            a list of indices of neighboring atoms.
-        """
-        return self.graph[idx]
-
-    # interaction vectors
-    def _add_interaction_vector(self, idx, vector_list):
-        """
-        Adds input vector list to the list of directional interaction vectors for a given atom index.
-
-        Parameters
-        ----------
-        idx: int
-            atom index
-        vector_list: list
-            list of directional interaction vectors
-
-        Returns
-        -------
-        None
-        """
-        while idx >= len(self.interaction_vector):
-            self.interaction_vector.append([])
-        for vec in vector_list:
-            self.interaction_vector[idx].append(vec)
-
-    # rings
-    def get_atom_rings(self, idx):
-        """
-        Returns a list of rings that the atom index belongs to.
-
-        Parameters
-        ----------
-        idx: int
-
-        Returns
-        -------
-        ring_id_list: list
-            A list of the ring ids that the given atom index belongs to.
-        """
-        if idx in self.atom_to_ring_id:
-            return self.atom_to_ring_id[idx]
-        return []
+    def get_interaction_vectors(self, atom_index: int):
+        if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
+            raise IndexError(
+                "GET_INTERACTION_VECTORS: provided atom index is out of range or is a dummy atom"
+            )
+        return self.atoms[atom_index].interaction_vectors
 
     # endregion
 
+    # def get_bonds_in_ring
+    # def walk_recursive
+    # def perceive_rings
+
+    # def merge_terminal_atoms(self, indices):
+    #     """
+    #     Primarily for merging hydrogens, but will merge the data for any atom or pseudoatom that is bonded to only one
+    #     other atom.
+    #
+    #     Parameters
+    #     ----------
+    #     indices: list
+    #         A list of indices to merge
+    #
+    #     Returns
+    #     -------
+    #     None
+    #     """
+    #     for index in indices:
+    #         if len(self.get_neighbors(index)) != 1:
+    #             msg = "Atempted to merge atom %d with %d neighbors. "
+    #             msg += "Only atoms with one neighbor can be merged."
+    #             msg = msg % (index + 1, self.get_neighbors(index))
+    #             raise RuntimeError(msg)
+    #         neighbor_index = self.get_neighbors(index)[0]
+    #         self.atoms[neighbor_index].charge += self.get_charge(index)
+    #         self.atoms[index].charge = 0.0
+    #         self.atoms[index].is_ignore = True
+    #     return
+
+
+# TODO: RENAME THIS TO NOT BE WORD VOMIT, CLEAN UP - Sets all the requirements for if you're building
+# A moleculesetup with an external toolkit like RDKit or OB
+class MoleculeSetupExternalToolBuild(ABC):
+
     @staticmethod
-    def get_bonds_in_ring(ring):
+    def are_fourier_series_identical(fs1, fs2):
         """
-        Gets the list of bonds in the specified ring, where each bond is a pair of atom indices.
-        Parameters
-        ----------
-        ring: list
-            a list of atom indices
-
-        Returns
-        -------
-        bonds: list
-            a list of bonds in the ring, where each bond is a pair of atom indices
+        NOT MODIFIED YET
         """
-        n = len(ring)
-        bonds = []
-        for i in range(n):
-            bond = (ring[i], ring[(i + 1) % n])
-            bond = (min(bond), max(bond))
-            bonds.append(bond)
-        return bonds
-
-    def walk_recursive(self, idx, collected=None, exclude=None):
-        """
-        Recursively walks the molecular graph and returns subgraphs that are bond-connected
-
-        Parameters
-        ----------
-        idx: int
-            atom index of the graph we want to walk
-        collected: list
-            an optional input list of subgraphs
-        exclude: list
-            a list of atom indices to exclude from the walk
-
-        Returns
-        -------
-        collected: list
-            a list of indices corresponding to a subgraph that is bond-connected
-        """
-        if collected is None:
-            collected = []
-        if exclude is None:
-            exclude = []
-        for neigh in self.get_neighbors(idx):
-            if neigh in exclude:
-                continue
-            collected.append(neigh)
-            exclude.append(neigh)
-            self.walk_recursive(neigh, collected, exclude)
-        return collected
-
-    def merge_terminal_atoms(self, indices):
-        """
-        Primarily for merging hydrogens, but will merge the data for any atom or pseudoatom that is bonded to only one
-        other atom.
-
-        Parameters
-        ----------
-        indices: list
-            A list of indices to merge
-
-        Returns
-        -------
-        None
-        """
-        for index in indices:
-            if len(self.graph[index]) != 1:
-                msg = "Atempted to merge atom %d with %d neighbors. "
-                msg += "Only atoms with one neighbor can be merged."
-                msg = msg % (index + 1, len(self.graph[index]))
-                raise RuntimeError(msg)
-            neighbor_index = self.graph[index][0]
-            self.charge[neighbor_index] += self.get_charge(index)
-            self.charge[index] = 0.0
-            self.set_ignore(index, True)
-
-    def perceive_rings(self, keep_chorded_rings, keep_equivalent_rings):
-        """
-        Populate the rings and aromatic rings atom tables.
-
-        Parameters
-        ----------
-        keep_chorded_rings: bool
-            flag indicating whether we want to keep chorded rings in the tables
-        keep_equivalent_rings
-            flag indicating whether we want to keep equivalent rings in the tables
-
-        Returns
-        -------
-        None
-        """
-
-        """ populate the rings and aromatic rings tables he atoms table:
-        self.rings_aromatics : list
-            contains the list of ring_id items that are aromatic
-        self.rings: dict
-            store information about rings, like if they have corners that can
-            be flipped and the graph of atoms that belong to them:
-
-                self.rings[ring_id] = {
-                                'corner_flip': False
-                                'graph': {}
-                                }
-
-            The atom is built using the `walk_recursive` method
-        self.ring_atom_to_ring_id: dict
-            mapping of each atom belonging to the ring: atom_idx -> ring_id
-        """
-
-        def isRingAromatic(ring_atom_indices):
-            for atom_idx1, atom_idx2 in self.get_bonds_in_ring(ring_atom_indices):
-                bond = self.mol.GetBondBetweenAtoms(atom_idx1, atom_idx2)
-                if not bond.GetIsAromatic():
+        index_by_periodicity1 = {
+            fs1[index]["periodicity"]: index for index in range(len(fs1))
+        }
+        index_by_periodicity2 = {
+            fs2[index]["periodicity"]: index for index in range(len(fs2))
+        }
+        if index_by_periodicity1 != index_by_periodicity2:
+            return False
+        for periodicity in index_by_periodicity1:
+            index1 = index_by_periodicity1[periodicity]
+            index2 = index_by_periodicity2[periodicity]
+            for key in ["k", "phase", "periodicity"]:
+                if fs1[index1][key] != fs2[index2][key]:
                     return False
-            return True
-
-        hjk_ring_detection = utils.HJKRingDetection(self.graph)
-        rings = hjk_ring_detection.scan(keep_chorded_rings, keep_equivalent_rings)  # list of tuples of atom indices
-        for ring_atom_idxs in rings:
-            if isRingAromatic(ring_atom_idxs):
-                self.rings_aromatic.append(ring_atom_idxs)
-            self.rings[ring_atom_idxs] = {'corner_flip': False}
-            graph = {}
-            for atom_idx in ring_atom_idxs:
-                self.atom_to_ring_id[atom_idx].append(ring_atom_idxs)
-                # graph of atoms affected by potential ring movements
-                graph[atom_idx] = self.walk_recursive(atom_idx, collected=[], exclude=list(ring_atom_idxs))
-            self.rings[ring_atom_idxs]['graph'] = graph
+        return True
 
     def add_dihedral_interaction(self, fourier_series):
         """
@@ -939,482 +460,30 @@ class MoleculeSetup:
         self.dihedral_interactions.append(safe_copy)
         return index
 
-    @staticmethod
-    def are_fourier_series_identical(fs1, fs2):
-        """
-
-        Parameters
-        ----------
-        fs1
-        fs2
-
-        Returns
-        -------
-
-        """
-        index_by_periodicity1 = {fs1[index]["periodicity"]: index for index in range(len(fs1))}
-        index_by_periodicity2 = {fs2[index]["periodicity"]: index for index in range(len(fs2))}
-        if index_by_periodicity1 != index_by_periodicity2:
-            return False
-        for periodicity in index_by_periodicity1:
-            index1 = index_by_periodicity1[periodicity]
-            index2 = index_by_periodicity2[periodicity]
-            for key in ["k", "phase", "periodicity"]:
-                if fs1[index1][key] != fs2[index2][key]:
-                    return False
-        return True
-
-    # region Separate Interface Candidates
-    def copy(self):
-        """
-        Creates a new, separate MoleculeSetup object and populates it with the same data as the current MoleculeSetup.
-
-        Returns
-        -------
-        newsetup: MoleculeSetup
-            A new MoleculeSetup object which has the same data as the current MoleculeSetup.
-        """
-        newsetup = MoleculeSetup()
-        newsetup.__dict__ = deepcopy(self.__dict__)
-        return newsetup
-
-    @classmethod
-    def from_mol(cls, mol, keep_chorded_rings=False, keep_equivalent_rings=False,
-                 assign_charges=True):
-        """
-        Creates an instance of a molsetup object and loads data into it from an RDKit mol object?
-
-        Parameters
-        ----------
-        mol: rdkit.Chem.rdchem.Mol
-            RDKit Mol to load data from.
-        keep_chorded_rings: bool
-            needs info
-        keep_equivalent_rings: bool
-            needs info
-        assign_charges: bool
-            needs info
-
-        Returns
-        -------
-        A new molsetup object with data from the provided mol.
-        The following fields would be populated: mol, atom_true_count_, name,
-
-        Note
-        ----
-        Why is this implemented here in this way when all of the methods it calls are methods we want the
-        inheriting classes to override? Its call signatures also seem to be consistent with the way methods are
-        defined in a very specific subclass of this class, so it would behoove us to consider the sublass/superclass
-        structure here.
-        """
-        molsetup = cls()
-        molsetup.mol = mol
-        molsetup.atom_true_count = molsetup.get_num_mol_atoms()
-        molsetup.name = molsetup.get_mol_name()
-        molsetup.init_atom(assign_charges)  # find a way to standardize signature across classes
-        molsetup.init_bond()
-        molsetup.perceive_rings(keep_chorded_rings, keep_equivalent_rings)
-        return molsetup
-
+    @abstractmethod
     def init_atom(self):
-        """ iterate through molecule atoms and build the atoms table """
-        raise NotImplementedError("This method must be overloaded by inheriting class")
-
-    def init_bond(self):
-        """ iterate through molecule bonds and build the bond table (id, table)
-            CALCULATE
-                bond_order: int
-                    0       : pseudo-bond (for pseudoatoms)
-                    1,2,3   : single-triple bond
-                    5       : aromatic
-                    999     : rigid
-
-                if bond is in ring (both start and end atom indices in the bond are in the same ring)
-
-            SETUP OPERATION
-                Setup.add_bond(idx1, idx2, order, rotatable)
-        """
-        raise NotImplementedError("This method must be overloaded by inheriting class")
-
-    def get_mol_name(self):
-        raise NotImplementedError("This method must be overloaded by inheriting class")
-
-    def find_pattern(self, smarts):
-        raise NotImplementedError("This method must be overloaded by inheriting class")
-
-    def get_smiles_and_order(self):
-        raise NotImplementedError("This method must be overloaded by inheriting class")
-
-    # endregion
-
-    # region String and JSON encoding
-    def write_xyz_string(self):
-        """
-
-        Returns
-        -------
-        output_string: str
-            A string writing out something to do with the coordinates and the elements.
-        """
-        n = len(self.element)
-        string = "%d\n\n" % n
-        for index in range(n):
-            if index < self.atom_true_count:
-                element = utils.mini_periodic_table[self.element[index]]
-            else:
-                element = "Ne"
-            x, y, z = self.coord[index]
-            string += "%3s %12.6f %12.6f %12.6f\n" % (element, x, y, z)
-        return string
-
-    def show(self):
-        """
-
-        Returns
-        -------
-
-        """
-        tot_charge = 0
-
-        print("Molecule setup\n")
-        print("==============[ ATOMS ]===================================================")
-        print("idx  |          coords            | charge |ign| atype    | connections")
-        print("-----+----------------------------+--------+---+----------+--------------- . . . ")
-        for k, v in enumerate(self.coord):
-            print("% 4d | % 8.3f % 8.3f % 8.3f | % 1.3f | %d" % (k, v[0], v[1], v[2],
-                                                                 self.charge[k], self.atom_ignore[k]),
-                  "| % -8s |" % self.atom_type[k],
-                  self.graph[k])
-            tot_charge += self.charge[k]
-        print("-----+----------------------------+--------+---+----------+--------------- . . . ")
-        print("  TOT CHARGE: %3.3f" % tot_charge)
-
-        print("\n======[ DIRECTIONAL VECTORS ]==========")
-        for k, v in enumerate(self.coord):
-            if k in self.interaction_vector:
-                print("% 4d " % k, self.atom_type[k], end=' ')
-
-        print("\n==============[ BONDS ]================")
-        # For sanity users, we won't show those keys for now
-        keys_to_not_show = ['bond_order', 'type']
-        for k, v in list(self.bond.items()):
-            t = ', '.join('%s: %s' % (i, j) for i, j in v.items() if not i in keys_to_not_show)
-            print("% 8s - " % str(k), t)
-
-        # _macrocycle_typer.show_macrocycle_scores(self)
-
-        print('')
-
-    def to_json(self):
-        return json.dumps(self, cls=MoleculeSetupEncoder)
-
-    @classmethod
-    def from_json(cls, json_string):
-        molsetup = json.loads(json_string, object_hook=cls.molsetup_json_decoder)
-        return molsetup
-
-    @staticmethod
-    def molsetup_json_decoder(obj):
-        """
-        Takes an object and attempts to decode it into a molecule setup object. Handles type conversions that it knows
-        about, otherwise leaves attributes as the output that JSON leaves them as
-
-        Parameters
-        ----------
-        obj: Object
-            This can be any object, but it should be a dictionary from deserializing a JSON of a molecule setup object.
-
-        Returns
-        -------
-        If the input is a dictionary corresponding to a molecule setup, will return a molecule setup with data
-        populated from the dictionary. Otherwise, returns the input object.
-
-        """
-        # If the input object is not a dict, we know that it will not be parsable and is unlikely to be usable or
-        # safe data, so we should ignore it.
-        if type(obj) is not dict:
-            return obj
-
-        # if there's a "mol" key in the input dictionary, then it's an RDKitMoleculeSetup
-        # as opposed to being the base class. OpenBabel MoleculeSetups are deprecated,
-        # assuming mol is an RDKit molecule, not an OpenBabel one.
-        if "mol" in obj:
-            mol = obj.pop("mol")
-            molsetup = RDKitMoleculeSetup()
-        else:
-            mol = None
-            molsetup = MoleculeSetup()
-
-        # check that all the keys we expect are in the object dictionary as a safety measure
-        expected_molsetup_keys = {"atom_pseudo", "coord", "charge", "pdbinfo", "atom_type", "atom_params",
-                                  "dihedral_interactions", "dihedral_partaking_atoms", "dihedral_labels", "atom_ignore",
-                                  "chiral", "atom_true_count", "graph", "bond", "element", "interaction_vector",
-                                  "flexibility_model", "ring_closure_info", "restraints", "is_sidechain",
-                                  "rmsd_symmetry_indices", "rings", "rings_aromatic", "atom_to_ring_id", "ring_corners",
-                                  "name", "rotamers",
-                                  }
-        if set(obj.keys()) != expected_molsetup_keys:
-            return obj
-
-        separator_char = ","
-        # creates a molecule setup and sets all the expected molsetup fields. Converts to desired type for molsetups.
-        molsetup.atom_pseudo = [int(v) for v in obj["atom_pseudo"]]
-        molsetup.coord = OrderedDict({int(k): np.asarray(v) for k, v in obj["coord"].items()})
-        molsetup.charge = OrderedDict({int(k): float(v) for k, v in obj["charge"].items()})
-        molsetup.pdbinfo = OrderedDict({int(k): PDBAtomInfo(*v) for k, v in obj["pdbinfo"].items()})
-        molsetup.atom_type = OrderedDict({int(k): v for k, v in obj["atom_type"].items()})
-        molsetup.atom_params = obj["atom_params"]
-        molsetup.dihedral_interactions = obj["dihedral_interactions"]
-        molsetup.dihedral_partaking_atoms = obj["dihedral_partaking_atoms"]
-        molsetup.dihedral_labels = obj["dihedral_labels"]
-        molsetup.atom_ignore = OrderedDict({int(k): v for k, v in obj["atom_ignore"].items()})
-        molsetup.chiral = OrderedDict({int(k): v for k, v in obj["chiral"].items()})
-        molsetup.atom_true_count = obj["atom_true_count"]
-        molsetup.graph = OrderedDict({int(k): v for k, v in obj["graph"].items()})
-        molsetup.bond = OrderedDict({tuple([int(i) for i in k.split(separator_char)]): v
-                                     for k, v in obj["bond"].items()})
-        molsetup.element = OrderedDict({int(k): v for k, v in obj["element"].items()})
-        molsetup.interaction_vector = OrderedDict(obj["interaction_vector"])
-        # Handling flexibility model dictionary of dictionaries
-        molsetup.flexibility_model = obj["flexibility_model"]
-        if 'rigid_body_connectivity' in molsetup.flexibility_model:
-            tuples_rigid_body_connectivity = \
-                {tuple([int(i) for i in k.split(separator_char)]): tuple(v)
-                 for k, v in molsetup.flexibility_model['rigid_body_connectivity'].items()}
-            molsetup.flexibility_model['rigid_body_connectivity'] = tuples_rigid_body_connectivity
-        if 'rigid_body_graph' in molsetup.flexibility_model:
-            molsetup.flexibility_model['rigid_body_graph'] = \
-                {int(k): v for k, v in molsetup.flexibility_model['rigid_body_graph'].items()}
-        if 'rigid_body_members' in molsetup.flexibility_model:
-            molsetup.flexibility_model['rigid_body_members'] = \
-                {int(k): v for k, v in molsetup.flexibility_model['rigid_body_members'].items()}
-
-        molsetup.ring_closure_info = obj["ring_closure_info"]
-        molsetup.restraints = \
-            [Restraint(v["atom_index"], tuple(v["target_xyz"]), v["kcal_per_angstrom_square"], v["delay_angstrom"])
-             for v in obj["restraints"]]
-        molsetup.is_sidechain = obj["is_sidechain"]
-        molsetup.rmsd_symmetry_indices = tuple([tuple(v) for v in obj["rmsd_symmetry_indices"]])
-        molsetup.rings = {tuple([int(i) for i in k.split(separator_char)]): v
-                          for k, v in obj["rings"].items()}
-        for key in molsetup.rings:
-            if 'graph' in molsetup.rings[key]:
-                molsetup.rings[key]['graph'] = {int(k): v for k, v in molsetup.rings[key]['graph'].items()}
-        molsetup.rings_aromatic = [tuple(v) for v in obj["rings_aromatic"]]
-        molsetup.atom_to_ring_id = obj["atom_to_ring_id"]
-        molsetup.atom_to_ring_id = {int(k): [tuple(t) for t in v] for k, v in obj['atom_to_ring_id'].items()}
-        molsetup.ring_corners = obj["ring_corners"]
-        molsetup.name = obj["name"]
-        molsetup.rotamers = obj["rotamers"]
-        if mol is not None:
-            rdkit_mols = rdMolInterchange.JSONToMols(mol)
-            if len(rdkit_mols) != 1:
-                raise ValueError(f"Expected 1 rdkit mol from json string but got {len(rdkit_mols)}")
-            molsetup.mol = rdkit_mols[0]
-        return molsetup
-
-    # endregion
-
-    # region Deprecated Code and Features
-    ###################################################################################################################
-    #   This section contains code that is deprecated, or that was left in the file despite being completely          #
-    #   commented out or otherwise non-functional. It wil be removed in future updates.                               #
-    ###################################################################################################################
-    @classmethod
-    # This functionality has been replaced by the work in LinkedRDKitChorizo, and therefore is no longer needed
-    # in MoleculeSetup itself.
-    def from_pdb_and_residue_params(cls, pdb_fname, residue_params_fname=None):
-        """
-        Creates an instance of a molsetup object and loads data into it from a pdb file and a parameter file.
-
-        Parameters
-        ----------
-        pdb_fname: string
-            the filepath for a pdb file to load data from
-        residue_params_fname: string or None
-            the filepath for residue parameters to be used in the molsetup
-        Returns
-        -------
-        A molsetup populated with data based off of the pdb, and if it was provided, the input parameters.
-        """
-        if residue_params_fname is not None:
-            with open(residue_params_fname) as f:
-                residue_params = json.load(f)
-        with open(pdb_fname) as f:
-            lines = f.readlines()
-        x = []
-        y = []
-        z = []
-        res_list = []
-        atom_names_list = []
-        last_res = None
-        pdbinfos = []
-        for line in lines:
-            if not (line.startswith("ATOM") or line.startswith("HETATM")):
-                continue
-            resn = line[17:20]
-            resi = int(line[22:26])
-            chain = line[21:22]
-            res = (resn, resi, chain)
-            if res != last_res:
-                res_list.append(resn)
-                atom_names_list.append([])
-            last_res = res
-            atom_name = line[12:16].strip()
-            atom_names_list[-1].append(atom_name)
-            x.append(float(line[30:38]))
-            y.append(float(line[38:46]))
-            z.append(float(line[46:54]))
-            pdbinfo = rdkitutils.PDBAtomInfo(
-                name=atom_name,
-                resName=resn,
-                resNum=resi,
-                chain=chain
-            )
-            pdbinfos.append(pdbinfo)
-
-        atom_params = {}
-        atom_counter = 0
-        all_ok = True
-        all_err = ""
-        for (res, atom_names) in zip(res_list, atom_names_list):
-            p, ok, err = PDBQTReceptor.get_params_for_residue(res, atom_names)
-            nr_params_to_add = set([len(values) for _, values in p.items()])
-            if len(nr_params_to_add) != 1:
-                raise RuntimeError("inconsistent number of parameters in %s" % p)
-            nr_params_to_add = nr_params_to_add.pop()
-            all_ok &= ok
-            all_err += err
-            for key in p:
-                atom_params.setdefault(key, [None] * atom_counter)
-                atom_params[key].extend(p[key])
-            atom_counter += nr_params_to_add
-            for key in atom_params:
-                if key not in p:
-                    atom_params[key].extend([None] * nr_params_to_add)
-
-        if not all_ok:
-            raise RuntimeError(all_err)
-
-        molsetup = cls()
-        charges = atom_params.pop("gasteiger")
-        atypes = atom_params.pop("atom_types")
-        for i in range(len(x)):
-            molsetup.add_atom(
-                i,
-                coord=(x[i], y[i], z[i]),
-                charge=charges[i],
-                atom_type=atypes[i],
-                element=None,
-                pdbinfo=pdbinfo,
-                chiral=False,
-                ignore=False,
-            )
-
-        molsetup.atom_params = atom_params
-
-        return molsetup
-
-    # These functions are not currently in use, evaluate whether they need to stay in molecule setups
-    def del_atom(self, idx):
-        """ remove an atom and update all data associate with it """
         pass
-        # coords
-        # charge
-        # element
-        # type
-        # neighbor graph
-        # ignore
-        # update bonds bonds (using the neighbor graph)
-        # If pseudo-atom, update other information, too
 
-    def is_aromatic(self, idx):
-        """
-        Checks if an atom at a particular atom index is in an aromatic ring.
-        Parameters
-        ----------
-        idx: int
-            atom index to check
+    @abstractmethod
+    def init_bond(self):
+        pass
 
-        Returns
-        -------
-        is_aromatic: bool
-            a boolean indicating whether the atom's index is recorded in an aromatic ring.
-        """
-        for r in self.rings_aromatic:
-            if idx in r:
-                return True
-        return False
+    @abstractmethod
+    def get_mol_name(self):
+        pass
 
-    def get_atom_indices(self, true_atoms_only=False):
-        """ return the indices of the atoms registered in the setup
-            if 'true_atoms_only' are requested, then pseudoatoms are ignored
-        """
-        indices = range(len(self.coord))
-        if true_atoms_only:
-            return [x for x in indices if x not in self.atom_pseudo]
-        return list(indices)
+    @abstractmethod
+    def find_pattern(self):
+        pass
 
-    def _get_attrib(self, idx, attrib, default=None):
-        """ generic function to provide a default for retrieving properties and returning standard values """
-        return getattr(self, attrib).get(idx, default)
+    @abstractmethod
+    def get_smiles_and_order(self):
+        pass
 
-    def copy_attributes_from(self, template):
-        """ copy attributes to duplicate the template setup
-        NOTE: the molecule will always keep the original setup (i.e., template)"""
-        for attr in self.attributes_to_copy:
-            attr_copy = deepcopy(getattr(template, attr))
-            setattr(self, attr, attr_copy)
-        self.mol = template.mol
-
-    def get_interaction_vector(self, idx):
-        """ get list of directional interaction vectors for atom idx"""
-        return self.interaction_vector[idx]
-
-    def del_interaction_vector(self, idx):
-        """ delete list of directional interaction vectors for atom idx"""
-        del self.interaction_vector[idx]
-
-    def set_pdbinfo(self, idx, data):
-        """ add PDB data (resname/num, atom name, etc.) to the atom """
-        self.pdbinfo[idx] = data
-
-    def set_bond(self, idx1, idx2, order=0, rotatable=False):
-        """
-        Populates the internal bond attribute with the specified bond and its properties, indexed by the bonds canonical
-        tuple bond id.
-
-        Parameters
-        ----------
-        idx1: int
-            the index of one of the atoms in the bond
-        idx2: int
-            the index of the other atom in the bond
-        order: int
-            the bond order
-        rotatable: bool
-            indicates whether the bond is rotatable
-
-        Returns
-        -------
-        None
-        """
-        bond_id = self.get_bond_id(idx1, idx2)
-        self.bond[bond_id] = {
-            'bond_order': order,
-            'rotatable': rotatable,
-        }
-
-    # def ring_atom_to_ring(self, arg):
-    #     return self.atom_to_ring_id[arg]
-
-    # def get_atom_ring_count(self, idx):
-    #     """ return the number of rings to which this atom belongs"""
-    #     return len(self.atom_to_ring_id[idx])
-    # endregion
+    pass
 
 
-class RDKitMoleculeSetup(MoleculeSetup):
+class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolBuild):
     """
     Subclass of MoleculeSetup, used to represent MoleculeSetup objects working with RDKit objects
 
@@ -1432,15 +501,25 @@ class RDKitMoleculeSetup(MoleculeSetup):
     """
 
     @classmethod
-    def from_mol(cls, mol, keep_chorded_rings=False, keep_equivalent_rings=False,
-                 assign_charges=True, conformer_id=-1):
+    def from_mol(
+        cls,
+        mol,
+        keep_chorded_rings=False,
+        keep_equivalent_rings=False,
+        assign_charges=True,
+        conformer_id=-1,
+    ):
         if cls.has_implicit_hydrogens(mol):
             raise ValueError("RDKit molecule has implicit Hs. Need explicit Hs.")
         if mol.GetNumConformers() == 0:
-            raise ValueError("RDKit molecule does not have a conformer. Need 3D coordinates.")
+            raise ValueError(
+                "RDKit molecule does not have a conformer. Need 3D coordinates."
+            )
         rdkit_conformer = mol.GetConformer(conformer_id)
         if not rdkit_conformer.Is3D():
-            warnings.warn("RDKit molecule not labeled as 3D. This warning won't show again.")
+            warnings.warn(
+                "RDKit molecule not labeled as 3D. This warning won't show again."
+            )
             RDKitMoleculeSetup.warned_not3D = True
         if mol.GetNumConformers() > 1 and conformer_id == -1:
             msg = "RDKit molecule has multiple conformers. Considering only the first one."
@@ -1459,9 +538,35 @@ class RDKitMoleculeSetup(MoleculeSetup):
         # the atom index, because not all atoms need to have new coordinates specified
         # Unspecified hydrogen positions bonded to modified heavy atom positions
         # are to be calculated "on-the-fly".
-        molsetup.modified_atom_positions = []  # list of dictionaries where keys are atom indices
+        molsetup.modified_atom_positions = (
+            []
+        )  # list of dictionaries where keys are atom indices
 
         return molsetup
+
+    # @classmethod
+    # def from_mol(
+    #     cls,
+    #     mol: rdkit.Chem.Mol,
+    #     keep_chorded_rings: bool = False,
+    #     keep_equivalent_rings: bool = False,
+    #     assign_charges: bool = True,
+    #     conformer_id: int = 1,
+    # ):
+    #     # Checks if the input molecule is valid
+    #     if has_implicit_hydrogens(mol):
+    #         raise ValueError("RDKit molecule has implicit Hs. Need explicit Hs.")
+    #     if mol.GetNumConformers(mol) == 0:
+    #         raise ValueError(
+    #             "RDKit molecule does not have a conformer. Need 3D coordinates."
+    #         )
+    #
+    #     # Gets the RDKit Conformer that we are going to load into the molecule setup
+    #     rdkit_conformer = mol.GetConformer(conformer_id)
+    #
+    #     # Creating and populating the molecule setup with properties from RDKit
+    #
+    #     pass
 
     def get_conformer_with_modified_positions(self, new_atom_positions):
         # we operate on one conformer at a time because SetTerminalAtomPositions
@@ -1495,8 +600,8 @@ class RDKitMoleculeSetup(MoleculeSetup):
 
     def get_smiles_and_order(self):
         """
-            return the SMILES after Chem.RemoveHs()
-            and the mapping between atom indices in smiles and self.mol
+        return the SMILES after Chem.RemoveHs()
+        and the mapping between atom indices in smiles and self.mol
         """
 
         ### # support sidechains in which not all real atoms are included in PDBQT
@@ -1518,7 +623,7 @@ class RDKitMoleculeSetup(MoleculeSetup):
         ###     for index in sorted(dangling_hs, reverse=True):
         ###         mol_no_ignore.RemoveAtom(index)
         ###     mol_no_ignore = mol_no_ignore.GetMol()
-        ###     Chem.SanitizeMol(mol_no_ignore) 
+        ###     Chem.SanitizeMol(mol_no_ignore)
         ### else:
         mol_no_ignore = self.mol
 
@@ -1541,28 +646,29 @@ class RDKitMoleculeSetup(MoleculeSetup):
         atomic_num_mol_noH = [atom.GetAtomicNum() for atom in mol_noH.GetAtoms()]
         noH_to_H = []
         parents_of_hs = {}
-        for (index, atom) in enumerate(mol_no_ignore.GetAtoms()):
-            if atom.GetAtomicNum() == 1: continue
+        for index, atom in enumerate(mol_no_ignore.GetAtoms()):
+            if atom.GetAtomicNum() == 1:
+                continue
             for i in range(len(noH_to_H), len(atomic_num_mol_noH)):
                 if atomic_num_mol_noH[i] > 1:
                     break
                 h_atom = mol_noH.GetAtomWithIdx(len(noH_to_H))
-                assert (h_atom.GetAtomicNum() == 1)
+                assert h_atom.GetAtomicNum() == 1
                 neighbors = h_atom.GetNeighbors()
-                assert (len(neighbors) == 1)
+                assert len(neighbors) == 1
                 parents_of_hs[len(noH_to_H)] = neighbors[0].GetIdx()
-                noH_to_H.append('H')
+                noH_to_H.append("H")
             noH_to_H.append(index)
         extra_hydrogens = len(atomic_num_mol_noH) - len(noH_to_H)
         if extra_hydrogens > 0:
-            assert (set(atomic_num_mol_noH[len(noH_to_H):]) == {1})
+            assert set(atomic_num_mol_noH[len(noH_to_H) :]) == {1}
         for i in range(extra_hydrogens):
             h_atom = mol_noH.GetAtomWithIdx(len(noH_to_H))
-            assert (h_atom.GetAtomicNum() == 1)
+            assert h_atom.GetAtomicNum() == 1
             neighbors = h_atom.GetNeighbors()
-            assert (len(neighbors) == 1)
+            assert len(neighbors) == 1
             parents_of_hs[len(noH_to_H)] = neighbors[0].GetIdx()
-            noH_to_H.append('H')
+            noH_to_H.append("H")
 
         # noH_to_H has the same length as the number of atoms in mol_noH
         # and each value is:
@@ -1575,34 +681,49 @@ class RDKitMoleculeSetup(MoleculeSetup):
             hs_by_parent.setdefault(pidx, [])
             hs_by_parent[pidx].append(hidx)
         for pidx, hidxs in hs_by_parent.items():
-            siblings_of_h = [atom for atom in mol_no_ignore.GetAtomWithIdx(noH_to_H[pidx]).GetNeighbors() if
-                             atom.GetAtomicNum() == 1]
-            sortidx = [i for i, j in sorted(list(enumerate(siblings_of_h)), key=lambda x: x[1].GetIdx())]
+            siblings_of_h = [
+                atom
+                for atom in mol_no_ignore.GetAtomWithIdx(noH_to_H[pidx]).GetNeighbors()
+                if atom.GetAtomicNum() == 1
+            ]
+            sortidx = [
+                i
+                for i, j in sorted(
+                    list(enumerate(siblings_of_h)), key=lambda x: x[1].GetIdx()
+                )
+            ]
             if len(hidxs) == len(siblings_of_h):
                 # This is the easy case, just map H to each other in the order they appear
                 for i, hidx in enumerate(hidxs):
                     noH_to_H[hidx] = siblings_of_h[sortidx[i]].GetIdx()
             elif len(hidxs) < len(siblings_of_h):
                 # check hydrogen isotopes
-                sibling_isotopes = [siblings_of_h[sortidx[i]].GetIsotope() for i in range(len(siblings_of_h))]
+                sibling_isotopes = [
+                    siblings_of_h[sortidx[i]].GetIsotope()
+                    for i in range(len(siblings_of_h))
+                ]
                 molnoH_isotopes = [mol_noH.GetAtomWithIdx(hidx) for hidx in hidxs]
                 matches = []
                 for i, sibling_isotope in enumerate(sibling_isotopes):
-                    for hidx in hidxs[len(matches):]:
+                    for hidx in hidxs[len(matches) :]:
                         if mol_noH.GetAtomWithIdx(hidx).GetIsotope() == sibling_isotope:
                             matches.append(i)
                             break
                 if len(matches) != len(hidxs):
                     raise RuntimeError(
-                        "Number of matched isotopes %d differs from query Hs: %d" % (len(matches), len(hidxs)))
+                        "Number of matched isotopes %d differs from query Hs: %d"
+                        % (len(matches), len(hidxs))
+                    )
                 for hidx, i in zip(hidxs, matches):
                     noH_to_H[hidx] = siblings_of_h[sortidx[i]].GetIdx()
             else:
-                raise RuntimeError("nr of Hs in mol_noH bonded to an atom exceeds nr of Hs in mol_no_ignore")
+                raise RuntimeError(
+                    "nr of Hs in mol_noH bonded to an atom exceeds nr of Hs in mol_no_ignore"
+                )
 
         smiles = Chem.MolToSmiles(mol_noH)
         order_string = mol_noH.GetProp("_smilesAtomOutputOrder")
-        order_string = order_string.replace(',]', ']')  # remove trailing comma
+        order_string = order_string.replace(",]", "]")  # remove trailing comma
         order = json.loads(order_string)  # mol_noH to smiles
         order = list(np.argsort(order))
         order = {noH_to_H[i]: order[i] + 1 for i in range(len(order))}  # 1-index
@@ -1627,19 +748,26 @@ class RDKitMoleculeSetup(MoleculeSetup):
     @staticmethod
     def get_symmetries_for_rmsd(mol, max_matches=17):
         mol_noHs = Chem.RemoveHs(mol)
-        matches = mol.GetSubstructMatches(mol_noHs, uniquify=False, maxMatches=max_matches)
+        matches = mol.GetSubstructMatches(
+            mol_noHs, uniquify=False, maxMatches=max_matches
+        )
         if len(matches) == max_matches:
             if mol.HasProp("_Name"):
                 molname = mol.GetProp("_Name")
             else:
                 molname = ""
             print(
-                "warning: found the maximum nr of matches (%d) in RDKitMolSetup.get_symmetries_for_rmsd" % max_matches)
-            print("Maybe this molecule is \"too\" symmetric? %s" % molname, Chem.MolToSmiles(mol_noHs))
+                "warning: found the maximum nr of matches (%d) in RDKitMolSetup.get_symmetries_for_rmsd"
+                % max_matches
+            )
+            print(
+                'Maybe this molecule is "too" symmetric? %s' % molname,
+                Chem.MolToSmiles(mol_noHs),
+            )
         return matches
 
     def init_atom(self, assign_charges, coords):
-        """ initialize the atom table information """
+        """initialize the atom table information"""
         # extract/generate charges
         if assign_charges:
             copy_mol = Chem.Mol(self.mol)
@@ -1647,7 +775,7 @@ class RDKitMoleculeSetup(MoleculeSetup):
                 if atom.GetAtomicNum() == 34:
                     atom.SetAtomicNum(16)
             rdPartialCharges.ComputeGasteigerCharges(copy_mol)
-            charges = [a.GetDoubleProp('_GasteigerCharge') for a in copy_mol.GetAtoms()]
+            charges = [a.GetDoubleProp("_GasteigerCharge") for a in copy_mol.GetAtoms()]
         else:
             charges = [0.0] * self.mol.GetNumAtoms()
         # perceive chirality
@@ -1660,17 +788,19 @@ class RDKitMoleculeSetup(MoleculeSetup):
             chiral = False
             if idx in chiral_info:
                 chiral = chiral_info[idx]
-            self.add_atom(idx,
-                          coord=coords[idx],
-                          element=a.GetAtomicNum(),
-                          charge=charges[idx],
-                          atom_type=None,
-                          pdbinfo=rdkitutils.getPdbInfoNoNull(a),
-                          chiral=False,
-                          ignore=False)
+            self.add_atom(
+                idx,
+                coord=coords[idx],
+                element=a.GetAtomicNum(),
+                charge=charges[idx],
+                atom_type=None,
+                pdbinfo=rdkitutils.getPdbInfoNoNull(a),
+                chiral=False,
+                ignore=False,
+            )
 
     def init_bond(self):
-        """ initialize bond information """
+        """initialize bond information"""
         for b in self.mol.GetBonds():
             idx1 = b.GetBeginAtomIdx()
             idx2 = b.GetEndAtomIdx()
@@ -1685,7 +815,7 @@ class RDKitMoleculeSetup(MoleculeSetup):
             self.add_bond(idx1, idx2, order=bond_order, rotatable=rotatable)
 
     def copy(self):
-        """ return a copy of the current setup"""
+        """return a copy of the current setup"""
         newsetup = RDKitMoleculeSetup()
         for key, value in self.__dict__.items():
             if key != "mol":
@@ -1704,7 +834,9 @@ class RDKitMoleculeSetup(MoleculeSetup):
                 return True
         return False
 
-    def restrain_to(self, target_mol, kcal_per_angstrom_square=1.0, delay_angstroms=2.0):
+    def restrain_to(
+        self, target_mol, kcal_per_angstrom_square=1.0, delay_angstroms=2.0
+    ):
         if not _has_misctools:
             raise ImportError(_import_misctools_error)
         stereo_isomorphism = StereoIsomorphism()
@@ -1714,7 +846,9 @@ class RDKitMoleculeSetup(MoleculeSetup):
         target_positions = target_mol.GetConformer().GetPositions()
         for atom_index in range(len(mapping)):
             target_xyz = target_positions[lig_to_drive[atom_index]]
-            restraint = Restraint(atom_index, target_xyz, kcal_per_angstrom_square, delay_angstroms)
+            restraint = Restraint(
+                atom_index, target_xyz, kcal_per_angstrom_square, delay_angstroms
+            )
             self.restraints.append(restraint)
         return
 
@@ -1744,13 +878,16 @@ class OBMoleculeSetup(MoleculeSetup):
         """initialize atom data table"""
         for a in ob.OBMolAtomIter(self.mol):
             partial_charge = a.GetPartialCharge() * float(assign_charges)
-            self.add_atom(a.GetIdx() - 1,
-                          coord=np.asarray(obutils.getAtomCoords(a), dtype='float'),
-                          element=a.GetAtomicNum(),
-                          charge=partial_charge,
-                          atom_type=None,
-                          pdbinfo=obutils.getPdbInfoNoNull(a),
-                          ignore=False, chiral=a.IsChiral())
+            self.add_atom(
+                a.GetIdx() - 1,
+                coord=np.asarray(obutils.getAtomCoords(a), dtype="float"),
+                element=a.GetAtomicNum(),
+                charge=partial_charge,
+                atom_type=None,
+                pdbinfo=obutils.getPdbInfoNoNull(a),
+                ignore=False,
+                chiral=a.IsChiral(),
+            )
             # TODO check consistency for chiral model between OB and RDKit
 
     def init_bond(self):
@@ -1764,8 +901,76 @@ class OBMoleculeSetup(MoleculeSetup):
             self.add_bond(idx1, idx2, order=bond_order)
 
     def copy(self):
-        """ return a copy of the current setup"""
+        """return a copy of the current setup"""
         return OBMoleculeSetup(template=self)
+
+
+@dataclass
+class Atom:
+    index: int
+    pdbinfo: str = DEFAULT_PDBINFO
+    charge: float = DEFAULT_CHARGE
+    element: int = DEFAULT_ELEMENT
+    atom_type: str = DEFAULT_ATOM_TYPE
+    is_ignore: bool = DEFAULT_IS_IGNORE
+    is_chiral: bool = DEFAULT_IS_CHIRAL
+    graph: list[int] = DEFAULT_GRAPH
+    interaction_vectors: list[np.array] = DEFAULT_INTERACTION_VECTORS
+
+    is_dummy: bool = False
+    is_pseudo_atom: bool = False
+
+
+@dataclass
+class Bond:
+    canon_id: (int, int)
+    index1: int
+    index2: int
+    order: int = DEFAULT_BOND_ORDER
+    rotatable: bool = DEFAULT_BOND_ROTATABLE
+
+    def __init__(
+        self,
+        index1: int,
+        index2: int,
+        order: int = DEFAULT_BOND_ORDER,
+        rotatable: bool = DEFAULT_BOND_ROTATABLE,
+    ):
+        self.canon_id = self.get_bond_id(index1, index2)
+        self.index1 = index1
+        self.index2 = index2
+        self.order = order
+        self.rotatable = rotatable
+        return
+
+    @staticmethod
+    def get_bond_id(idx1: int, idx2: int):
+        """
+        Generates a consistent, "canonical", bond id from a pair of atom indices in the graph.
+
+        Parameters
+        ----------
+        idx1: int
+            atom index of one of the atoms in the bond
+        idx2: int
+            atom index of the other atom in the bond
+
+        Returns
+        -------
+        canon_id: tuple
+            a tuple of the two indices in their canonical order.
+        """
+        idx_min = min(idx1, idx2)
+        idx_max = max(idx1, idx2)
+        return idx_min, idx_max
+
+
+@dataclass
+class Ring:
+    ring_id: int
+    corner_flip: bool = DEFAULT_RING_CORNER_FLIP
+    graph: dict = DEFAULT_RING_GRAPH
+    is_aromatic: bool = DEFAULT_RING_IS_AROMATIC
 
 
 class UniqAtomParams:
@@ -1822,7 +1027,9 @@ class UniqAtomParams:
         """
         nr_items = set([len(values) for key, values in atom_params.items()])
         if len(nr_items) != 1:
-            raise RuntimeError(f"all lists in atom_params must have same length, got {nr_items}")
+            raise RuntimeError(
+                f"all lists in atom_params must have same length, got {nr_items}"
+            )
         if set(atom_params) != set(self.param_names):
             msg = f"parameter names in atom_params differ from internal ones\n"
             msg += f"  - in atom_params: {set(atom_params)}"
@@ -1866,11 +1073,13 @@ class UniqAtomParams:
         self.params.append(new_row)
         return new_row_index
 
-    def add_molsetup(self, molsetup, atom_params=None, add_atomic_nr=False, add_atom_type=False):
+    def add_molsetup(
+        self, molsetup, atom_params=None, add_atomic_nr=False, add_atom_type=False
+    ):
         if "q" in molsetup.atom_params or "atom_type" in molsetup.atom_params:
             msg = '"q" and "atom_type" found in molsetup.atom_params'
-            msg += ' but are hard-coded to store molsetup.charge and'
-            msg += ' molsetup.atom_type in the internal data structure'
+            msg += " but are hard-coded to store molsetup.charge and"
+            msg += " molsetup.atom_type in the internal data structure"
             raise RuntimeError(msg)
         if atom_params is None:
             atom_params = molsetup.atom_params
@@ -1882,11 +1091,15 @@ class UniqAtomParams:
                 p = {k: v[atom_index] for (k, v) in molsetup.atom_params.items()}
                 if add_atomic_nr:
                     if "atomic_nr" in p:
-                        raise RuntimeError("trying to add atomic_nr but it's already in atom_params")
+                        raise RuntimeError(
+                            "trying to add atomic_nr but it's already in atom_params"
+                        )
                     p["atomic_nr"] = molsetup.element[atom_index]
                 if add_atom_type:
                     if "atom_type" in p:
-                        raise RuntimeError("trying to add atom_type but it's already in atom_params")
+                        raise RuntimeError(
+                            "trying to add atom_type but it's already in atom_params"
+                        )
                     p["atom_type"] = molsetup.atom_type[atom_index]
                 param_idx = self.add_parameter(p)
             param_idxs.append(param_idx)
@@ -1901,103 +1114,11 @@ class Restraint:
     delay_angstroms: float
 
     def copy(self):
-        new_target_xyz = (
-            self.target_xyz[0],
-            self.target_xyz[1],
-            self.target_xyz[2])
+        new_target_xyz = (self.target_xyz[0], self.target_xyz[1], self.target_xyz[2])
         new_restraint = Restraint(
             self.atom_index,
             new_target_xyz,
             self.kcal_per_angstrom_square,
-            self.delay_angstroms)
+            self.delay_angstroms,
+        )
         return new_restraint
-
-
-# TODO: refactor molsetup class then refactor this and consider making it more readable.
-class MoleculeSetupEncoder(json.JSONEncoder):
-    """
-    JSON Encoder class for molecule setup objects. Makes decisions about how to convert types to JSON serializable types
-    so they can be reliably decoded should a user want to pull the JSON back into an object.
-    """
-
-    def default(self, obj):
-        """
-        Overrides the default JSON encoder for data structures for Molecule Setup objects.
-
-        Parameters
-        ----------
-        obj: object
-            Can take any object as input, but will only create the MoleculeSetup JSON format for MoleculeSetup objects.
-            For all other objects will return the default JSON encoding.
-
-        Returns
-        -------
-        A JSON serializable object that represents the MoleculeSetup class or the default JSONEncoder output for an
-        object.
-        """
-        # Checks if the input object is a MoleculeSetup as desired
-        if isinstance(obj, MoleculeSetup):
-            separator_char = ","  # TODO: consider setting this somewhere else so it is the same for decode and encode
-            # Sets the elements of an output dict of attributes based off of all the attributes that are guaranteed to
-            # be present and
-            output_dict = {
-                # Attributes that are dictionaries mapping from atom index to some other property
-                "coord": {k: v.tolist() for k, v in obj.coord.items()},  # converts coords from numpy arrays to lists
-                "charge": obj.charge,
-                "pdbinfo": obj.pdbinfo,
-                "atom_type": obj.atom_type,
-                "atom_ignore": obj.atom_ignore,
-                "chiral": obj.chiral,
-                "graph": obj.graph,
-                "element": obj.element,
-                "interaction_vector": obj.interaction_vector,
-                "atom_to_ring_id": obj.atom_to_ring_id,
-
-                # Dihedral
-                "dihedral_interactions": obj.dihedral_interactions,
-                "dihedral_partaking_atoms": obj.dihedral_partaking_atoms,
-                "dihedral_labels": obj.dihedral_labels,
-
-                # Dictionaries with tuple keys have the tuples converted to strings
-                "bond": {separator_char.join([str(i) for i in k]): v for k, v in obj.bond.items()},
-                "rings": {separator_char.join([str(i) for i in k]): v for k, v in obj.rings.items()},
-
-                # Dictionaries of dictionaries
-                "atom_params": obj.atom_params,
-                "flexibility_model": obj.flexibility_model,
-                "ring_closure_info": obj.ring_closure_info,
-
-                # Lists
-                "atom_pseudo": obj.atom_pseudo,
-                "restraints": [asdict(restraint) for restraint in obj.restraints],
-                "rings_aromatic": obj.rings_aromatic,
-                "rotamers": obj.rotamers,
-
-                # Simple variables
-                "atom_true_count": obj.atom_true_count,
-                "is_sidechain": obj.is_sidechain,
-                "name": obj.name,
-
-                "rmsd_symmetry_indices": obj.rmsd_symmetry_indices,
-            }
-            # Since the flexibility model attribute contains dictionaries with tuples as keys, it needs to be treated
-            # more specifically.
-            if 'rigid_body_connectivity' in obj.flexibility_model:
-                new_rigid_body_conn_dict = {separator_char.join([str(i) for i in k]): v
-                                            for k, v in obj.flexibility_model['rigid_body_connectivity'].items()}
-                output_dict["flexibility_model"] = \
-                    {k: (v if k != 'rigid_body_connectivity' else new_rigid_body_conn_dict)
-                     for k, v in obj.flexibility_model.items()}
-
-            # Adds mol attribute if the input MoleculeSetup is an RDKitMoleculeSetup
-            if isinstance(obj, RDKitMoleculeSetup):
-                output_dict["mol"] = rdMolInterchange.MolToJSON(obj.mol)
-            return output_dict
-        # If the input object is not a MoleculeSetup, returns the default JSON encoding for that object
-        return json.JSONEncoder.default(self, obj)
-
-
-@dataclass
-class BondProperties:
-    order: int
-    rotatable: bool

--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -118,13 +118,13 @@ class MoleculeSetup:
     """
 
     def __init__(self):
-        # Simple attributes defining the molecule setup
+        # Simple attributes defining core properties of the molecule setup
         self.atom_true_count = 0
         self.is_sidechain = False
         self.name = None
 
         # Internal lists and keyword dicts.
-        self.atom_pseudo = []
+        self.atom_pseudo = [] # List of pseudoatom indices
         self.atom_params = {}
         self.restraints = []
         self.rotamers = []
@@ -388,38 +388,18 @@ class MoleculeSetup:
         rotatable: bool
             whether the bond is rotatable
         """
-        # Checks that
-        if not idx2 in self.graph[idx1]:
+        # Checks that the bond is represented in the graph property
+        if idx2 not in self.graph[idx1]:
             self.graph[idx1].append(idx2)
-        if not idx1 in self.graph[idx2]:
+        if idx1 not in self.graph[idx2]:
             self.graph[idx2].append(idx1)
-        self.set_bond(idx1, idx2, order, rotatable)
-
-    def set_bond(self, idx1, idx2, order=0, rotatable=False):
-        """
-        Populates the internal bond attribute with the specified bond and its properties, indexed by the bonds canonical
-        tuple bond id.
-
-        Parameters
-        ----------
-        idx1: int
-            the index of one of the atoms in the bond
-        idx2: int
-            the index of the other atom in the bond
-        order: int
-            the bond order
-        rotatable: bool
-            indicates whether the bond is rotatable
-
-        Returns
-        -------
-        None
-        """
+        # Gets the canonical bond id and ads the bond infommration to the bond dictionary.
         bond_id = self.get_bond_id(idx1, idx2)
         self.bond[bond_id] = {
             'bond_order': order,
             'rotatable': rotatable,
         }
+        self.set_bond(idx1, idx2, order, rotatable)
 
     def get_bond(self, idx1, idx2):
         """
@@ -484,12 +464,11 @@ class MoleculeSetup:
         """
         idx_min = min(idx1, idx2)
         idx_max = max(idx1, idx2)
-        return (idx_min, idx_max)
+        return idx_min, idx_max
 
         # replaced by
 
     def add_rotamer(self, indices_list, angles_list):
-
         xyz = self.coord
         rotamer = {}
         for (i1, i2, i3, i4), angle in zip(indices_list, angles_list):
@@ -807,6 +786,7 @@ class MoleculeSetup:
         if idx in self.atom_to_ring_id:
             return self.atom_to_ring_id[idx]
         return []
+
     # endregion
 
     @staticmethod
@@ -1035,6 +1015,7 @@ class MoleculeSetup:
         molsetup.init_bond()
         molsetup.perceive_rings(keep_chorded_rings, keep_equivalent_rings)
         return molsetup
+
     def init_atom(self):
         """ iterate through molecule atoms and build the atoms table """
         raise NotImplementedError("This method must be overloaded by inheriting class")
@@ -1397,6 +1378,32 @@ class MoleculeSetup:
     def set_pdbinfo(self, idx, data):
         """ add PDB data (resname/num, atom name, etc.) to the atom """
         self.pdbinfo[idx] = data
+
+    def set_bond(self, idx1, idx2, order=0, rotatable=False):
+        """
+        Populates the internal bond attribute with the specified bond and its properties, indexed by the bonds canonical
+        tuple bond id.
+
+        Parameters
+        ----------
+        idx1: int
+            the index of one of the atoms in the bond
+        idx2: int
+            the index of the other atom in the bond
+        order: int
+            the bond order
+        rotatable: bool
+            indicates whether the bond is rotatable
+
+        Returns
+        -------
+        None
+        """
+        bond_id = self.get_bond_id(idx1, idx2)
+        self.bond[bond_id] = {
+            'bond_order': order,
+            'rotatable': rotatable,
+        }
 
     # def ring_atom_to_ring(self, arg):
     #     return self.atom_to_ring_id[arg]

--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -21,7 +21,7 @@ from .utils import rdkitutils
 # region DEFAULT VALUES
 DEFAULT_PDBINFO = None
 DEFAULT_CHARGE = 0.0
-DEFAULT_ELEMENT = None
+DEFAULT_ATOMIC_NUM = None
 DEFAULT_ATOM_TYPE = None
 DEFAULT_IS_IGNORE = False
 DEFAULT_IS_CHIRAL = False
@@ -156,7 +156,7 @@ class UniqAtomParams:
                         raise RuntimeError(
                             "trying to add atomic_nr but it's already in atom_params"
                         )
-                    p["atomic_nr"] = molsetup.element[atom_index]
+                    p["atomic_nr"] = molsetup.atomic_num[atom_index]
                 if add_atom_type:
                     if "atom_type" in p:
                         raise RuntimeError(
@@ -171,7 +171,7 @@ class UniqAtomParams:
 class MoleculeSetup:
 
     # region CLASS CONSTANTS
-    PSEUDOATOM_ELEMENT = 0
+    PSEUDOATOM_ATOMIC_NUM = 0
     # endregion
 
     def __init__(self, name: str = None, is_sidechain: bool = False):
@@ -200,7 +200,7 @@ class MoleculeSetup:
         overwrite: bool = False,
         pdbinfo: str = DEFAULT_PDBINFO,
         charge: float = DEFAULT_CHARGE,
-        element: int = DEFAULT_ELEMENT,
+        atomic_num: int = DEFAULT_ATOMIC_NUM,
         atom_type: str = DEFAULT_ATOM_TYPE,
         is_ignore: bool = DEFAULT_IS_IGNORE,
         is_chiral: bool = DEFAULT_IS_CHIRAL,
@@ -217,7 +217,7 @@ class MoleculeSetup:
         overwrite: bool
         pdbinfo: str
         charge: float
-        element: int
+        atomic_num: int
         atom_type: str
         is_ignore: bool
         is_chiral: bool
@@ -251,7 +251,7 @@ class MoleculeSetup:
 
         # Creates and adds new atom to the atom list
         new_atom = Atom(
-            atom_index, pdbinfo, charge, element, atom_type, is_ignore, is_chiral, graph
+            atom_index, pdbinfo, charge, atomic_num, atom_type, is_ignore, is_chiral, graph
         )
         if atom_index < len(self.atoms):
             self.atoms[atom_index] = new_atom
@@ -292,7 +292,7 @@ class MoleculeSetup:
             pseudoatom_index,
             pdbinfo=pdbinfo,
             charge=charge,
-            element=self.PSEUDOATOM_ELEMENT,
+            atomic_num=self.PSEUDOATOM_ATOMIC_NUM,
             atom_type=atom_type,
             is_ignore=is_ignore,
             is_pseudo_atom=True,
@@ -440,12 +440,12 @@ class MoleculeSetup:
             )
         return self.atoms[atom_index].charge
 
-    def get_element(self, atom_index: int):
+    def get_atomic_num(self, atom_index: int):
         if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
             raise IndexError(
-                "GET_ELEMENT: provided atom index is out of range or is a dummy atom"
+                "GET_ATOMIC_NUM: provided atom index is out of range or is a dummy atom"
             )
-        return self.atoms[atom_index].element
+        return self.atoms[atom_index].atomic_num
 
     def get_atom_type(self, atom_index: int):
         if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
@@ -923,7 +923,7 @@ class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolBuild):
             self.add_atom(
                 idx,
                 coord=coords[idx],
-                element=a.GetAtomicNum(),
+                atomic_num=a.GetAtomicNum(),
                 charge=charges[idx],
                 atom_type=None,
                 pdbinfo=rdkitutils.getPdbInfoNoNull(a),
@@ -1013,7 +1013,7 @@ class OBMoleculeSetup(MoleculeSetup):
             self.add_atom(
                 a.GetIdx() - 1,
                 coord=np.asarray(obutils.getAtomCoords(a), dtype="float"),
-                element=a.GetAtomicNum(),
+                atomic_num=a.GetAtomicNum(),
                 charge=partial_charge,
                 atom_type=None,
                 pdbinfo=obutils.getPdbInfoNoNull(a),
@@ -1042,7 +1042,7 @@ class Atom:
     index: int
     pdbinfo: str = DEFAULT_PDBINFO
     charge: float = DEFAULT_CHARGE
-    element: int = DEFAULT_ELEMENT
+    atomic_num: int = DEFAULT_ATOMIC_NUM
     atom_type: str = DEFAULT_ATOM_TYPE
     is_ignore: bool = DEFAULT_IS_IGNORE
     is_chiral: bool = DEFAULT_IS_CHIRAL

--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -7,7 +7,7 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import json
 import sys
 import warnings
@@ -24,8 +24,6 @@ DEFAULT_ELEMENT = None
 DEFAULT_ATOM_TYPE = None
 DEFAULT_IS_IGNORE = False
 DEFAULT_IS_CHIRAL = False
-DEFAULT_GRAPH = field(default_factory=list)
-DEFAULT_INTERACTION_VECTORS = field(default_factory=list)
 
 DEFAULT_BOND_ORDER = 0
 DEFAULT_BOND_ROTATABLE = False
@@ -66,13 +64,13 @@ class MoleculeSetup:
         self,
         atom_index: int = None,
         overwrite: bool = False,
-        pdbinfo: string = DEFAULT_PDBINFO,
+        pdbinfo: str = DEFAULT_PDBINFO,
         charge: float = DEFAULT_CHARGE,
         element: int = DEFAULT_ELEMENT,
-        atom_type: str = DEFAULT_TYPE,
+        atom_type: str = DEFAULT_ATOM_TYPE,
         is_ignore: bool = DEFAULT_IS_IGNORE,
         is_chiral: bool = DEFAULT_IS_CHIRAL,
-        graph: list[int] = DEFAULT_GRAPH,
+        graph: list[int] = field(default_factory=list),
     ):
         """
         Adds an atom with all the specified attributes to the MoleculeSetup, either at the specified atom index, or by
@@ -122,7 +120,7 @@ class MoleculeSetup:
             atom_index, pdbinfo, charge, element, atom_type, is_ignore, is_chiral, graph
         )
         if atom_index < len(self.atoms):
-            atoms[atom_index] = new_atom
+            self.atoms[atom_index] = new_atom
             return
         self.atoms.append(new_atom)
         return
@@ -160,7 +158,7 @@ class MoleculeSetup:
             pseudoatom_index,
             pdbinfo=pdbinfo,
             charge=charge,
-            element=PSEUDOATOM_ELEMENT,
+            element=self.PSEUDOATOM_ELEMENT,
             atom_type=atom_type,
             is_ignore=is_ignore,
             is_pseudo_atom=True,
@@ -196,7 +194,7 @@ class MoleculeSetup:
         atom_index_1: int,
         atom_index_2: int,
         order: int = DEFAULT_BOND_ORDER,
-        rotatable: bool = DEFAULT_BOND_ROTABLE,
+        rotatable: bool = DEFAULT_BOND_ROTATABLE,
     ):
         """
 
@@ -914,8 +912,8 @@ class Atom:
     atom_type: str = DEFAULT_ATOM_TYPE
     is_ignore: bool = DEFAULT_IS_IGNORE
     is_chiral: bool = DEFAULT_IS_CHIRAL
-    graph: list[int] = DEFAULT_GRAPH
-    interaction_vectors: list[np.array] = DEFAULT_INTERACTION_VECTORS
+    graph: list[int] = field(default_factory=list)
+    interaction_vectors: list[np.array] = field(default_factory=list)
 
     is_dummy: bool = False
     is_pseudo_atom: bool = False

--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -1430,7 +1430,24 @@ class Restraint:
 
 # TODO: refactor molsetup class then refactor this and consider making it more readable.
 class MoleculeSetupEncoder(json.JSONEncoder):
+    """
+    JSON Encoder class for molecule setup objects.
+    """
     def default(self, obj):
+        """
+        Overrides the default JSON encoder for data structures for Molecule Setup objects.
+
+        Parameters
+        ----------
+        obj: object
+            Can take any object as input, but will only create the Molsetup JSON format for Molsetup objects. For all
+            other objects will return the default json encoding.
+
+        Returns
+        -------
+        A JSON serializable object that represents the MoleculeSetup class or the default JSONEncoder output for an
+        object.
+        """
         if isinstance(obj, MoleculeSetup):
             return {
                 "atom_pseudo": obj.atom_pseudo,
@@ -1461,5 +1478,4 @@ class MoleculeSetupEncoder(json.JSONEncoder):
                 "name": obj.name,
                 "rotamers": obj.rotamers
             }
-            # return obj.__dict__ -> numpy arrays are not json serializable via json dumps
         return json.JSONEncoder.default(self, obj)

--- a/meeko/openff_xml_parser.py
+++ b/meeko/openff_xml_parser.py
@@ -26,7 +26,7 @@ def get_openff_epsilon_sigma(rdmol, vdw_list, vdw_by_type, output_index_start=0)
     mk_prep = MoleculePreparation.from_config(meeko_config)
     mk_prep.prepare(rdmol)
     molsetup = mk_prep.setup
-    for i, atype in molsetup.atom_type.items():
+    for i, atype in enumerate(molsetup.atom_type):
         data[i + output_index_start] = {
             "atom_type": atype,
             "epsilon": vdw_by_type[atype]["epsilon"],

--- a/meeko/preparation.py
+++ b/meeko/preparation.py
@@ -205,7 +205,7 @@ class MoleculePreparation:
             group_keys = list(atom_params.keys())
             if len(group_keys) != 1:
                 msg = "add_atom_types is usable only when there is one group of parameters"
-                msg += ", but there are %d groups: %s" % (len(keys), str(keys))
+                msg += ", but there are %d groups: %s" % (len(group_keys), str(group_keys))
                 raise RuntimeError(msg)
             key = group_keys[0]
             atom_params[key].extend(add_atom_types)
@@ -312,7 +312,7 @@ class MoleculePreparation:
         # merge hydrogens (or any terminal atoms)
         indices = set()
         for atype_to_merge in self.merge_these_atom_types:
-            for index, atype in setup.atom_type.items():
+            for index, atype in enumerate(setup.atom_type):
                 if atype == atype_to_merge:
                     indices.add(index)
         setup.merge_terminal_atoms(indices)
@@ -361,7 +361,13 @@ class MoleculePreparation:
             setups = []
             for r in reactive_types_dicts:
                 new_setup = setup.copy()
-                new_setup.atom_type = r
+                # There is no guarantee that the addition order in the dictionary will be the correct order to
+                # create the list in, so first sorts the keys from the dictionary then extracts the values in order
+                # to construct the new atom type list.
+                sorted_keys = list(r.keys())
+                sorted_keys.sort()
+                new_setup_atom_type = [r[idx] for idx in sorted_keys]
+                new_setup.atom_type = new_setup_atom_type
                 setups.append(new_setup)
 
         self.deprecated_setup_access = setups[0] # for a gentle introduction of the new API

--- a/meeko/writer.py
+++ b/meeko/writer.py
@@ -433,7 +433,7 @@ class PDBQTWriterLegacy():
             resname = chorizo.residues[res_id].input_resname
             ### molsetup_mapidx = {} if chorizo.residues[res_id].molsetup_mapidx is None else chorizo.residues[res_id].molsetup_mapidx
             is_flexres_atom = chorizo.residues[res_id].is_flexres_atom
-            for i, atom_ignore in molsetup.atom_ignore.items():
+            for i, atom_ignore in enumerate(molsetup.atom_ignore):
                 if atom_ignore or is_flexres_atom[i]:
                     continue
                 atom_type = molsetup.atom_type[i]
@@ -447,7 +447,7 @@ class PDBQTWriterLegacy():
                 chain, resname, resnum = res_id.split(":")
                 molsetup = chorizo.residues[res_id].molsetup
                 original_ignore = molsetup.atom_ignore.copy()
-                molsetup.atom_ignore = {i: ig or not is_flexres_atom[i] for (i, ig) in molsetup.atom_ignore.items()}
+                molsetup.atom_ignore = [ig or not is_flexres_atom[i] for (i, ig) in enumerate(molsetup.atom_ignore)]
                 this_flex_pdbqt, ok, err = PDBQTWriterLegacy.write_string(molsetup, remove_smiles=True)
                 molsetup.atom_ignore = original_ignore
                 if not ok:

--- a/meeko/writer.py
+++ b/meeko/writer.py
@@ -24,7 +24,7 @@ def oids_json_from_setup(molsetup, name="LigandFromMeeko"):
     offchrg_by_parent = {}
     for i in molsetup.atom_pseudo:
         if molsetup.atom_type[i] == offchrg_type:
-            neigh = molsetup.get_neigh(i)
+            neigh = molsetup.get_neighbors(i)
             if len(neigh) != 1:
                 raise RuntimeError("offsite charge %s is bonded to: %s which has len() != 1" % (
                     i, json.dumps(neigh)))
@@ -122,7 +122,7 @@ def oids_block_from_setup(molsetup, name="LigandFromMeeko"):
     offchrg_by_parent = {}
     for i in molsetup.atom_pseudo:
         if molsetup.atom_type[i] == offchrg_type:
-            neigh = molsetup.get_neigh(i)
+            neigh = molsetup.get_neighbors(i)
             if len(neigh) != 1:
                 raise RuntimeError("offsite charge %s is bonded to: %s which has len() != 1" % (
                     i, json.dumps(neigh)))
@@ -519,8 +519,8 @@ class PDBQTWriterLegacy():
                         success = False
                         return pdbqt_string, success, error_msg
                     missing_h.append(key)
-                    parents = setup.get_neigh(key)
-                    parents = [i for i in parents if i < setup.atom_true_count]  # exclude pseudos
+                    parents = setup.get_neighbors(key)
+                    parents = [i for i in parents if i < setup.atom_true_count] # exclude pseudos
                     if len(parents) != 1:
                         error_msg += "expected hydrogen to be bonded to exactly one atom"
                         error_msg += " (mol name: %s)\n" % setup.get_mol_name()

--- a/meeko_temp_task_refinement/MOLSETUP_NOTES.md
+++ b/meeko_temp_task_refinement/MOLSETUP_NOTES.md
@@ -1,0 +1,91 @@
+# Molecule Setup Notes
+
+This is a document meant as a temporary stop-gap to help us get technical tasks organized.
+This one pertains specifically to molecule setups, and contains notes, bugs, and feature 
+requests from the original molsetup.py file as well as details for plans to further update
+and refactor molecule setups, and information about the status of what has been done so far.
+
+### Implementation Notes From The Original File
+
+* Modify so there are no more dictionaries and only lists/arrays.
+  * methods like `add_x`, `delete_x`, `get_x` wil deal with indexing
+* Provide infrastructure to calculate "differential"
+modifications, like tautomers: the class calculating tautomers will copy and modify the setup 
+to swap protons and change the atom types (and possibly rotations?), then
+there will e a function to extract only differences (i.e., atom types and coordinates,
+in the case of tautomers) and store them to make it a switch-state
+* Only use 1-dimensional arrays (C)
+* Update `add_atom` to not specify neighbors, which should be defined only when a bond is created?
+* Change all attributes_to_copy to have underscore?
+* There was a note in a commented out function called `get_atom_ring_count` that said that it should be
+replaced by `get_atom_rings`. `Get_atom_rings` exists now in some form right below this comment.
+* `self.get_atom_rings` should replace `get_atom_ring_count`
+* Evaluate if `_get_attrib` is useful
+* In `del_bond`, check if we want to delete nodes that have no connections (we might want to
+keep them)
+* In `copy_attributes_from`:  enable some kind of plugin system here too, to allow other 
+\objects to add attributes? ALthough this would make the setup more fragile -> better to have
+attributes explicitly added here and that's it
+* After the `setattr` line of `copy_attributes_from` there is a todo marking a potential bug. The molecule
+is shared by the different setups. If one of them alters the molecule, properties will not be the same.
+* In the RDKit implementation of init_atom, there is a todo to check the consiostency for chiral model between
+OB and RDKit
+
+### Refactoring Molecule Setups
+
+#### Proposed Changes
+* Eliminate dictionaries and add support to checks that make sure the molecule setup is a valid molecule setup.
+  1. Convert all of the dictionaries that used to be ordered dicts mapping from array index to some property to lists.
+  2. Ensure that there are the checks mentioned in the original comment in add, delete, and get functions.
+  3. Determine if there are additional molsetup-wide checks that we want to do to make sure (for instance) that all
+     populated lists are the same length.
+* Create enums for `atom_type`, `atom_params`, `flexibility_model`, where we want only certain defined values to appear
+  (confirm with other people in the lab on what these should be and what variables it would be a good idea to do this 
+   for)
+  * Current observed `atom_type` values in Meeko are as follows: atom_type, rmin_half, epsilon, pull_charge_fraction,
+    gasteiger, atype
+* Clean up the inheritance and interface design
+  * More strictly define what is a function that we need the inheriting classes to define and what is a function that is
+    fully implemented in the parent MoleculeSetup class.
+  * Make sure call signatures for functions are consistent between parent and subclasses.
+  * Refine what we're using formal vs informal interfaces for.
+* Variables that are specific to specific subclasses should not be mentioned or initialized in the parent MoleculeSetup 
+  class.
+  * Currently the only identified ones are mol and rmsd_symmetry_indices, check if this is incorrect.
+* Clean up and fully comment `from_prmtop_inpcrd`. Check existing comments for accuracy as they are full of assumptions 
+  Parnika made.
+* Organize Molecule Setup class so all the getters and setters are together, and that functionality is generally grouped
+  * Reconsider the use of getters and setters, convert the appropriate attributes to properties and limit access
+    as necessary
+* Fully comment and document.
+  * `add_pseudo_atom` needs info
+  * `write_xyz_string` needs info
+* Rethink the organization of the information storage (potentially pull out certain pieces of data to be in their own
+  data structures/classes if it makes logical sense to group them and if they're being set at a particular time).
+* Remove coords from molsetups (they will be stored elsewhere, likely in a different data structure)
+* Define what variables get initialized when in Molecule Setups (so what is a basic MoleculeSetup object vs what is 
+  a populated MoleculeSetup), and modify the variable initialization to reflect this.
+* Add unit tests for all of the MoleculeSetup functions.
+* Fill out unit tests for all the MoleculeSetup functions, confirm with other members of the lab that these are the
+  correct test cases to have and that we're covering edge and corner cases to the best of our ability.
+* Refactor all functions to be stricter about types and to be more robust for checks.
+  * Make sure all variable names make sense and that there is less room for ambiguity/interpretation
+  * Get rid of magic numbers (typically int or float literals that are in places in code)
+  * Make sure all loops are clear and well-documented
+
+#### Implemented Changes
+* Convert OrderedDict collection to dicts since newer versions of python dictionaries maintain insertion order.
+* Refine existing tasks for Molecule Setups
+
+### Open Questions
+* Are we deprecating/deleting `del_atom` or is it functionality we still want to add. It currently exists as
+the shell of a function that could be.
+* Re: Stefano's earlier comments on `get_atom_rings`, is any of that still relevant or are we leaving the current
+implementation as-is
+* I have decided to leave all of the inits as literals rather than `dict()` and `list()` declarations because it is
+a bit more efficient, but the other choice might be a little bit clearer to a reader unfamiliar with Python. I do not
+think it would be unreasonable to expect a reader to be familiar with Python, but I thought it would be good to formally
+point this out.
+* Is there a particular reason why there is exactly one dict that is using defaultdict? How heavily are we relying on
+  that?
+* Both atom and pseudoatom add methods have this overwrite feature, and we are manually tracking pseudatoms 

--- a/meeko_temp_task_refinement/MOLSETUP_NOTES.md
+++ b/meeko_temp_task_refinement/MOLSETUP_NOTES.md
@@ -39,11 +39,9 @@ OB and RDKit
   2. Ensure that there are the checks mentioned in the original comment in add, delete, and get functions.
   3. Determine if there are additional molsetup-wide checks that we want to do to make sure (for instance) that all
      populated lists are the same length.
-* Create enums for `atom_type`, `atom_params`, `flexibility_model`, where we want only certain defined values to appear
-  (confirm with other people in the lab on what these should be and what variables it would be a good idea to do this 
-   for)
-  * Current observed `atom_type` values in Meeko are as follows: atom_type, rmin_half, epsilon, pull_charge_fraction,
-    gasteiger, atype
+* Note: Current observed `atom_type` values in Meeko are as follows: atom_type, rmin_half, epsilon, pull_charge_fraction,
+  gasteiger, atype
+* Rethink the way that `atom_params` values are stored, consider creating a class for them
 * Clean up the inheritance and interface design
   * More strictly define what is a function that we need the inheriting classes to define and what is a function that is
     fully implemented in the parent MoleculeSetup class.
@@ -51,7 +49,7 @@ OB and RDKit
   * Refine what we're using formal vs informal interfaces for.
 * Variables that are specific to specific subclasses should not be mentioned or initialized in the parent MoleculeSetup 
   class.
-  * Currently the only identified ones are mol and rmsd_symmetry_indices, check if this is incorrect.
+  * Currently the only identified ones are `mol` and `rmsd_symmetry_indices`, check if this is incorrect.
 * Clean up and fully comment `from_prmtop_inpcrd`. Check existing comments for accuracy as they are full of assumptions 
   Parnika made.
 * Organize Molecule Setup class so all the getters and setters are together, and that functionality is generally grouped
@@ -76,6 +74,8 @@ OB and RDKit
 #### Implemented Changes
 * Convert OrderedDict collection to dicts since newer versions of python dictionaries maintain insertion order.
 * Refine existing tasks for Molecule Setups
+* Eliminate dictionaries and add support to checks that make sure the molecule setup is a valid molecule setup.
+  1. Convert all of the dictionaries that used to be ordered dicts mapping from array index to some property to lists.
 
 ### Open Questions
 * Are we deprecating/deleting `del_atom` or is it functionality we still want to add. It currently exists as

--- a/meeko_temp_task_refinement/MOLSETUP_NOTES.md
+++ b/meeko_temp_task_refinement/MOLSETUP_NOTES.md
@@ -70,6 +70,7 @@ OB and RDKit
   * Make sure all variable names make sense and that there is less room for ambiguity/interpretation
   * Get rid of magic numbers (typically int or float literals that are in places in code)
   * Make sure all loops are clear and well-documented
+* Add functions to get true atom indices and pseudoatom indices for external purposes
 
 #### Implemented Changes
 * Convert OrderedDict collection to dicts since newer versions of python dictionaries maintain insertion order.

--- a/scripts/mk_prepare_receptor.py
+++ b/scripts/mk_prepare_receptor.py
@@ -466,8 +466,8 @@ if not args.skip_gpf:
         for res_id_tuple in reactive_flexres.keys():
             res_id = f"{res_id_tuple[0]}:{res_id_tuple[1]}:{res_id_tuple[2]}"
             molsetup = chorizo.residues[res_id].molsetup
-            calpha_idx = [i for i, pdbinfo in molsetup.pdbinfo.items() if pdbinfo.name == "CA"]
-            cbeta_idx = [i for i, pdbinfo in molsetup.pdbinfo.items() if pdbinfo.name == "CB"]
+            calpha_idx = [i for i, pdbinfo in enumerate(molsetup.pdbinfo) if pdbinfo.name == "CA"]
+            cbeta_idx = [i for i, pdbinfo in enumerate(molsetup.pdbinfo) if pdbinfo.name == "CB"]
             if len(calpha_idx) != 1:
                 check(success=False, error_msg=f"found {len(calpha_idx)} CA in {res_id} but expected 1")
             if len(cbeta_idx) != 1:
@@ -540,7 +540,7 @@ if not args.skip_gpf:
         for res_id, res in chorizo.residues.items():
             if not res.is_movable:
                 continue
-            for index, coord in res.molsetup.coord.items():
+            for index, coord in enumerate(res.molsetup.coord):
                 if not res.is_flexres_atom[index]:
                     continue
                 if gridbox.is_point_outside_box(coord, box_center, npts):

--- a/test/json_serialization_test.py
+++ b/test/json_serialization_test.py
@@ -39,6 +39,8 @@ def populated_rdkit_molsetup():
 
 # Test Cases
 def test_rdkit_molsetup_encoding_decoding():
+    # TODO: Certain fields are empty in this example, and if we want to make sure that json is working in all scenarios
+    # we will need to make other tests for those empty fields.
     # Encode and decode molsetup from json
     starting_molsetup = populated_rdkit_molsetup()
     json_str = json.dumps(starting_molsetup, cls=MoleculeSetupEncoder)
@@ -48,11 +50,17 @@ def test_rdkit_molsetup_encoding_decoding():
     assert isinstance(starting_molsetup, RDKitMoleculeSetup)
     assert isinstance(decoded_molsetup, RDKitMoleculeSetup)
 
+    # First checks the attributes that we are not doing any type conversion on
+
+    # Next checks attributes that needed minimal type conversion
+
+    # Finally goes through attributes that needed complex interventions
+
     # Bool used while looping through values to check whether all values in a data structure have the expected type
     correct_val_type = True
     # Go through molsetup attributes and check that they are the expected type and match the molsetup object
     # before serialization.
-    assert decoded_molsetup.atom_pseudo == starting_molsetup.atom_pseudo # EMPTY
+    assert decoded_molsetup.atom_pseudo == starting_molsetup.atom_pseudo  # EMPTY
     assert isinstance(decoded_molsetup.coord, collections.OrderedDict)
     assert decoded_molsetup.coord.keys() == starting_molsetup.coord.keys()
     for key in decoded_molsetup.coord:
@@ -66,12 +74,37 @@ def test_rdkit_molsetup_encoding_decoding():
     #    correct_val_type = correct_val_type & isinstance(decoded_molsetup.pdbinfo[key], PDBAtomInfo)
     assert correct_val_type
     assert decoded_molsetup.atom_type == starting_molsetup.atom_type
-    assert decoded_molsetup.atom_params == starting_molsetup.atom_params # WILL THERE BE CONVERSIONS NEEDED?
-    assert decoded_molsetup.dihedral_interactions == starting_molsetup.dihedral_interactions # EMPTY
-    assert decoded_molsetup.dihedral_partaking_atoms == starting_molsetup.dihedral_partaking_atoms # EMPTY
-    assert decoded_molsetup.dihedral_labels == starting_molsetup.dihedral_labels # EMPTY
+    assert decoded_molsetup.atom_params == starting_molsetup.atom_params  # WILL THERE BE CONVERSIONS NEEDED FOR PARAMS?
+    assert decoded_molsetup.dihedral_interactions == starting_molsetup.dihedral_interactions  # EMPTY
+    assert decoded_molsetup.dihedral_partaking_atoms == starting_molsetup.dihedral_partaking_atoms  # EMPTY
+    assert decoded_molsetup.dihedral_labels == starting_molsetup.dihedral_labels  # EMPTY
     assert decoded_molsetup.atom_ignore == starting_molsetup.atom_ignore
     assert decoded_molsetup.chiral == starting_molsetup.chiral
     assert decoded_molsetup.atom_true_count == starting_molsetup.atom_true_count
     assert decoded_molsetup.graph == starting_molsetup.graph
+    # Assert that the starting object's bond attribute was not compromised in the serialization process:
+    assert isinstance(list(starting_molsetup.bond.keys())[0], tuple)
+    # Assert that the final object's bond attribute had the expected key type:
+    assert isinstance(list(decoded_molsetup.bond.keys())[0], tuple)
     assert decoded_molsetup.bond == starting_molsetup.bond
+    assert decoded_molsetup.element == starting_molsetup.element
+    assert decoded_molsetup.interaction_vector == starting_molsetup.interaction_vector  # EMPTY
+    # Assert that both the starting and final objects have keys that are the expected type
+    if 'rigid_body_connectivity' in starting_molsetup.flexibility_model:
+        assert isinstance(list(starting_molsetup.flexibility_model['rigid_body_connectivity'].keys())[0], tuple)
+        assert isinstance(list(decoded_molsetup.flexibility_model['rigid_body_connectivity'].keys())[0], tuple)
+    assert decoded_molsetup.flexibility_model == starting_molsetup.flexibility_model
+    assert decoded_molsetup.ring_closure_info == starting_molsetup.ring_closure_info # EMPTY
+    assert decoded_molsetup.restraints == starting_molsetup.restraints # EMPTY
+    assert decoded_molsetup.is_sidechain == starting_molsetup.is_sidechain
+    assert decoded_molsetup.rmsd_symmetry_indices == starting_molsetup.rmsd_symmetry_indices
+    # Assert that the starting object's bond attribute was not compromised in the serialization process:
+    assert isinstance(list(starting_molsetup.bond.keys())[0], tuple)
+    # Assert that the final object's bond attribute had the expected key type:
+    assert isinstance(list(decoded_molsetup.bond.keys())[0], tuple)
+    assert decoded_molsetup.rings == starting_molsetup.rings
+    assert decoded_molsetup.rings_aromatic == starting_molsetup.rings_aromatic
+    assert decoded_molsetup.atom_to_ring_id == starting_molsetup.atom_to_ring_id
+    assert decoded_molsetup.ring_corners == starting_molsetup.ring_corners # EMPTY
+    assert decoded_molsetup.name == starting_molsetup.name # EMPTY
+    assert decoded_molsetup.rotamers == starting_molsetup.rotamers # empty

--- a/test/json_serialization_test.py
+++ b/test/json_serialization_test.py
@@ -1,0 +1,77 @@
+import collections
+import json
+import meeko
+import numpy
+import pathlib
+import pytest
+
+from meeko import (
+    ChorizoResidue,
+    ChorizoResidueEncoder,
+    LinkedRDKitChorizo,
+    MoleculePreparation,
+    MoleculeSetup,
+    MoleculeSetupEncoder,
+    RDKitMoleculeSetup,
+    ResidueAdditionalConnection,
+)
+
+#from ..meeko.utils.pdbutils import PDBAtomInfo
+
+pkgdir = pathlib.Path(meeko.__file__).parents[1]
+
+# Test Data
+ahhy_example = pkgdir / "example/chorizo/AHHY.pdb"
+
+
+# Fixtures
+#@pytest.fixture
+def populated_rdkit_molsetup():
+    file = open(ahhy_example)
+    pdb_str = file.read()
+    chorizo = LinkedRDKitChorizo(pdb_str)
+    molecule_prep = MoleculePreparation()
+    # To add RDKit Mol to molecule setup
+    chorizo.flexibilize_protein_sidechain("A:TYR:4", molecule_prep)
+    residue = chorizo.residues["A:TYR:4"]
+    return residue.molsetup
+
+
+# Test Cases
+def test_rdkit_molsetup_encoding_decoding():
+    # Encode and decode molsetup from json
+    starting_molsetup = populated_rdkit_molsetup()
+    json_str = json.dumps(starting_molsetup, cls=MoleculeSetupEncoder)
+    decoded_molsetup = json.loads(json_str, object_hook=MoleculeSetup.molsetup_json_decoder)
+
+    # First asserts that all types are as expected
+    assert isinstance(starting_molsetup, RDKitMoleculeSetup)
+    assert isinstance(decoded_molsetup, RDKitMoleculeSetup)
+
+    # Bool used while looping through values to check whether all values in a data structure have the expected type
+    correct_val_type = True
+    # Go through molsetup attributes and check that they are the expected type and match the molsetup object
+    # before serialization.
+    assert decoded_molsetup.atom_pseudo == starting_molsetup.atom_pseudo # EMPTY
+    assert isinstance(decoded_molsetup.coord, collections.OrderedDict)
+    assert decoded_molsetup.coord.keys() == starting_molsetup.coord.keys()
+    for key in decoded_molsetup.coord:
+        correct_val_type = correct_val_type & isinstance(decoded_molsetup.coord[key], numpy.ndarray)
+        assert set(decoded_molsetup.coord[key]) == set(starting_molsetup.coord[key])
+    assert correct_val_type
+    assert decoded_molsetup.charge == starting_molsetup.charge
+    assert decoded_molsetup.pdbinfo == starting_molsetup.pdbinfo
+    correct_val_type = True
+    # for key in decoded_molsetup.pdbinfo:
+    #    correct_val_type = correct_val_type & isinstance(decoded_molsetup.pdbinfo[key], PDBAtomInfo)
+    assert correct_val_type
+    assert decoded_molsetup.atom_type == starting_molsetup.atom_type
+    assert decoded_molsetup.atom_params == starting_molsetup.atom_params # WILL THERE BE CONVERSIONS NEEDED?
+    assert decoded_molsetup.dihedral_interactions == starting_molsetup.dihedral_interactions # EMPTY
+    assert decoded_molsetup.dihedral_partaking_atoms == starting_molsetup.dihedral_partaking_atoms # EMPTY
+    assert decoded_molsetup.dihedral_labels == starting_molsetup.dihedral_labels # EMPTY
+    assert decoded_molsetup.atom_ignore == starting_molsetup.atom_ignore
+    assert decoded_molsetup.chiral == starting_molsetup.chiral
+    assert decoded_molsetup.atom_true_count == starting_molsetup.atom_true_count
+    assert decoded_molsetup.graph == starting_molsetup.graph
+    assert decoded_molsetup.bond == starting_molsetup.bond

--- a/test/json_serialization_test.py
+++ b/test/json_serialization_test.py
@@ -14,6 +14,7 @@ from meeko import (
     MoleculeSetupEncoder,
     RDKitMoleculeSetup,
     ResidueAdditionalConnection,
+    Restraint
 )
 
 #from ..meeko.utils.pdbutils import PDBAtomInfo
@@ -94,8 +95,8 @@ def test_rdkit_molsetup_encoding_decoding():
         assert isinstance(list(starting_molsetup.flexibility_model['rigid_body_connectivity'].keys())[0], tuple)
         assert isinstance(list(decoded_molsetup.flexibility_model['rigid_body_connectivity'].keys())[0], tuple)
     assert decoded_molsetup.flexibility_model == starting_molsetup.flexibility_model
-    assert decoded_molsetup.ring_closure_info == starting_molsetup.ring_closure_info # EMPTY
-    assert decoded_molsetup.restraints == starting_molsetup.restraints # EMPTY
+    assert decoded_molsetup.ring_closure_info == starting_molsetup.ring_closure_info  # EMPTY
+    assert decoded_molsetup.restraints == starting_molsetup.restraints  # EMPTY
     assert decoded_molsetup.is_sidechain == starting_molsetup.is_sidechain
     assert decoded_molsetup.rmsd_symmetry_indices == starting_molsetup.rmsd_symmetry_indices
     # Assert that the starting object's bond attribute was not compromised in the serialization process:
@@ -105,6 +106,6 @@ def test_rdkit_molsetup_encoding_decoding():
     assert decoded_molsetup.rings == starting_molsetup.rings
     assert decoded_molsetup.rings_aromatic == starting_molsetup.rings_aromatic
     assert decoded_molsetup.atom_to_ring_id == starting_molsetup.atom_to_ring_id
-    assert decoded_molsetup.ring_corners == starting_molsetup.ring_corners # EMPTY
-    assert decoded_molsetup.name == starting_molsetup.name # EMPTY
-    assert decoded_molsetup.rotamers == starting_molsetup.rotamers # empty
+    assert decoded_molsetup.ring_corners == starting_molsetup.ring_corners  # EMPTY
+    assert decoded_molsetup.name == starting_molsetup.name  # EMPTY
+    assert decoded_molsetup.rotamers == starting_molsetup.rotamers  # EMPTY

--- a/test/molsetup_test.py
+++ b/test/molsetup_test.py
@@ -1,0 +1,28 @@
+from meeko import MoleculeSetup
+
+import pathlib
+import pytest
+
+import meeko
+
+
+# region Fixtures
+# We may want to find a different place for these as tests get more complex structure and revisions.
+@pytest.fixture
+def empty_molecule_setup():
+    molsetup = MoleculeSetup()
+    yield molsetup
+# endregion
+
+class TestMoleculeSetupInit:
+    def test_add_one_atom(self):
+        pass
+
+    def test_add_one_pseudo_atom(self):
+        pass
+
+    def test_add_multiple_atoms(self):
+        pass
+
+    def test_add_bonds(self):
+        pass


### PR DESCRIPTION
A complete restructure of the `MoleculeSetup` class (including subclasses like `RDKitMoleculeSetup` and `OBMoleculeSetup`) to make MoleculeSetups more readable, more maintainable, and clean up inheritance between MoleculeSetups and subclasses.

- Adds several helper dataclasses to group and manage data in the `MoleculeSetup` class and eliminate synchronized OrderedDicts. These include the `Atom`, `Ring`, and `Bond` dataclasses.
- Enforces stricter typing on most variables, functions, and methods.
- Enforces default values for all classes
- More cleanly separates `MoleculeSetup` and `RDKitMoleculeSetup`, makes sure to isolate all methods and variables that depend on RDKit to be assigned or to work to `RDKitMoleculeSetup`.
- More clearly establishes external toolkit subclass extension requirements
- Cleans up JSON serialization and deserialization for `MoleculeSetup` objects and subclasses,

What remains to be done:

- Examine attributes like `flexibility_model` and `atom_params` to see if they can be converted from dictionaries to something more easily managed and checked.
- Clear out lesser used functionality
- Finalize documentation by double checking TODOs with team.