### PR TITLE
Macrocycle simplify

### DIFF
--- a/meeko/__init__.py
+++ b/meeko/__init__.py
@@ -23,7 +23,7 @@ else:
 from .preparation import MoleculePreparation
 from .molsetup import RDKitMoleculeSetup
 from .molsetup import MoleculeSetup
-from .molsetup import MoleculeSetupEncoder
+# from .molsetup import MoleculeSetupEncoder
 from .molsetup import Restraint
 from .molsetup import UniqAtomParams
 from .utils import rdkitutils

--- a/meeko/linked_rdkit_chorizo.py
+++ b/meeko/linked_rdkit_chorizo.py
@@ -13,7 +13,7 @@ from prody.atomic.selection import Selection
 
 from .writer import PDBQTWriterLegacy
 from .molsetup import MoleculeSetup
-from .molsetup import MoleculeSetupEncoder
+# from .molsetup import MoleculeSetupEncoder
 from .utils.rdkitutils import mini_periodic_table
 from .utils.rdkitutils import react_and_map
 from .utils.prodyutils import prody_to_rdkit, ALLOWED_PRODY_TYPES

--- a/meeko/macrocycle.py
+++ b/meeko/macrocycle.py
@@ -75,27 +75,19 @@ class FlexMacrocycle:
     def _score_bond(self, bond):
         """ provide a score for the likeness of the bond to be broken"""
         bond = self.setup.get_bond_id(bond[0], bond[1])
-        atom_idx1, atom_idx2 = bond
-        score = 100
-
-        bond_order = self.setup.bond[bond]['bond_order']
-        if bond_order not in [1, 2, 3]: # aromatic, double, made rigid explicitly (order=1.1 from --rigidify)
+        if not self.setup.bond[bond]['rotatable']:
             return -1
+        atom_idx1, atom_idx2 = bond
         if self.setup.atom_type[atom_idx1] != "C":
             return -1
         if self.setup.atom_type[atom_idx2] != "C":
             return -1
-        # triple bond tolerated but not preferred (TODO true?)
-        if bond_order == 3:
-            score -= 30
-        elif (bond_order == 2):
-            score -= self._double_bond_penalty
-        if bond in self._conj_bond_list:
-            score -= 30
-        # discourage chiral atoms
-        if self.setup.get_chiral(atom_idx1) or self.setup.get_chiral(atom_idx2):
-            score -= 20
-        return score
+        # historically we returned a score <= 100, that was lower for triple
+        # bonds, chiral atoms, conjugated bonds, and double bonds. This score
+        # gets combined with the graph depth score in flexibility.py that
+        # is lower when more consecutive torsions exist in a single "branch"
+        # of the torsion tree. Any positive number can be returned here.
+        return 100
 
     def get_breakable_bonds(self, bonds_in_rigid_rings):
         """ find breaking points for rings

--- a/meeko/macrocycle.py
+++ b/meeko/macrocycle.py
@@ -28,7 +28,6 @@ class FlexMacrocycle:
 
         self.setup = None
         self.breakable_rings = None
-        self._conj_bond_list = None
 
     def collect_rings(self, setup):
         """ get non-aromatic rings of desired size and
@@ -57,20 +56,6 @@ class FlexMacrocycle:
                 bonds_in_rigid_cycles.add(bond)
 
         return breakable_rings, bonds_in_rigid_cycles 
-
-    def _detect_conj_bonds(self):
-        """ detect bonds in conjugated systems
-        """
-        # TODO this should be removed once atom typing will be done
-        conj_bond_list = []
-        # pattern = "[R0]=[R0]-[R0]=[R0]" # Does not match conjugated bonds inside  the macrocycle?
-        pattern = '*=*[*]=,#,:[*]' # from SMARTS_InteLigand.txt
-        found = self.setup.find_pattern(pattern)
-        for f in found:
-            bond = (f[1], f[2])
-            bond = (min(bond), max(bond))
-            conj_bond_list.append(bond)
-        return conj_bond_list
 
     def _score_bond(self, bond):
         """ provide a score for the likeness of the bond to be broken"""
@@ -120,7 +105,6 @@ class FlexMacrocycle:
         self.setup = setup
 
         self.breakable_rings, bonds_in_rigid_rings = self.collect_rings(setup)
-        self._conj_bond_list = self._detect_conj_bonds()
         if len(delete_these_bonds) == 0:
             breakable_bonds = self.get_breakable_bonds(bonds_in_rigid_rings)
         else:

--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -16,6 +16,7 @@ import numpy as np
 import rdkit.Chem
 from rdkit import Chem
 from rdkit.Chem import rdPartialCharges
+from .utils import rdkitutils
 
 # region DEFAULT VALUES
 DEFAULT_PDBINFO = None
@@ -32,6 +33,139 @@ DEFAULT_RING_CORNER_FLIP = False
 DEFAULT_RING_GRAPH = defaultdict
 DEFAULT_RING_IS_AROMATIC = False
 # endregion
+
+
+class UniqAtomParams:
+    """
+    A helper class used to keep parameters organized in a particular way that lets them be more usable.
+
+    Attributes
+    ----------
+    params: list[]
+        can be thought of as rows
+    param_names: list[]
+        can be thought of as columns
+    """
+
+    def __init__(self):
+        self.params = []  # aka rows
+        self.param_names = []  # aka column names
+
+    @classmethod
+    def from_dict(cls, dictionary):
+        """
+        Creates an UniqAtomParams object, populates it with information from the input dictionary, then returns
+        the new object.
+
+        Parameters
+        ----------
+        dictionary: dict()
+            A dictionary containing the keys "params" and "param_names", where the value for "params" is parseable as
+            rows and the value for "param_names" contains the corresponding column data.
+
+        Returns
+        -------
+        A populated UniqAtomParams object
+        """
+        uap = UniqAtomParams()
+        uap.params = [row.copy() for row in dictionary["params"]]
+        uap.param_names = dictionary["param_names"].copy()
+        return uap
+
+    def get_indices_from_atom_params(self, atom_params):
+        """
+        Retrieves the indices of specific atom parameters in the UniqAtomParams object.
+
+        Parameters
+        ----------
+        atom_params: dict()
+            A dict with keys that correspond to the param names already in the UniqAtomParams object. The values are
+            lists that should all be the same size, and
+
+        Returns
+        -------
+        A list of indices corresponding to the order of parameters in the atom_params value lists that indicates the
+        index of that "row" of parameters in UniqAtomParams params.
+        """
+        nr_items = set([len(values) for key, values in atom_params.items()])
+        if len(nr_items) != 1:
+            raise RuntimeError(
+                f"all lists in atom_params must have same length, got {nr_items}"
+            )
+        if set(atom_params) != set(self.param_names):
+            msg = f"parameter names in atom_params differ from internal ones\n"
+            msg += f"  - in atom_params: {set(atom_params)}"
+            msg += f"  - internal: {set(self.param_names)}"
+            raise RuntimeError(msg)
+        nr_items = nr_items.pop()
+        param_idxs = []
+        for i in range(nr_items):
+            row = [atom_params[key][i] for key in self.param_names]
+            param_index = None
+            for j, existing_row in enumerate(self.params):
+                if row == existing_row:
+                    param_index = j
+                    break
+            param_idxs.append(param_index)
+        return param_idxs
+
+    def add_parameter(self, new_param_dict):
+        # remove None values to avoid a column with only Nones
+        new_param_dict = {k: v for k, v in new_param_dict.items() if v is not None}
+        incoming_keys = set(new_param_dict.keys())
+        existing_keys = set(self.param_names)
+        new_keys = incoming_keys.difference(existing_keys)
+        for new_key in new_keys:
+            self.param_names.append(new_key)
+            for row in self.params:
+                row.append(None)  # fill in empty "cell" in new "column"
+
+        new_row = []
+        for key in self.param_names:
+            value = new_param_dict.get(key, None)
+            new_row.append(value)
+
+        if len(new_keys) == 0:  # try to match with existing row
+            for index, row in enumerate(self.params):
+                if row == new_row:
+                    return index
+
+        # if we are here, we didn't match
+        new_row_index = len(self.params)
+        self.params.append(new_row)
+        return new_row_index
+
+    def add_molsetup(
+        self, molsetup, atom_params=None, add_atomic_nr=False, add_atom_type=False
+    ):
+        if "q" in molsetup.atom_params or "atom_type" in molsetup.atom_params:
+            msg = '"q" and "atom_type" found in molsetup.atom_params'
+            msg += " but are hard-coded to store molsetup.charge and"
+            msg += " molsetup.atom_type in the internal data structure"
+            raise RuntimeError(msg)
+        if atom_params is None:
+            atom_params = molsetup.atom_params
+        param_idxs = []
+        for atom_index, ignore in enumerate(molsetup.atom_ignore):
+            if ignore:
+                param_idx = None
+            else:
+                p = {k: v[atom_index] for (k, v) in molsetup.atom_params.items()}
+                if add_atomic_nr:
+                    if "atomic_nr" in p:
+                        raise RuntimeError(
+                            "trying to add atomic_nr but it's already in atom_params"
+                        )
+                    p["atomic_nr"] = molsetup.element[atom_index]
+                if add_atom_type:
+                    if "atom_type" in p:
+                        raise RuntimeError(
+                            "trying to add atom_type but it's already in atom_params"
+                        )
+                    p["atom_type"] = molsetup.atom_type[atom_index]
+                param_idx = self.add_parameter(p)
+            param_idxs.append(param_idx)
+        return param_idxs
 
 
 class MoleculeSetup:
@@ -969,139 +1103,6 @@ class Ring:
     corner_flip: bool = DEFAULT_RING_CORNER_FLIP
     graph: dict = DEFAULT_RING_GRAPH
     is_aromatic: bool = DEFAULT_RING_IS_AROMATIC
-
-
-class UniqAtomParams:
-    """
-    A helper class used to keep parameters organized in a particular way that lets them be more usable.
-
-    Attributes
-    ----------
-    params: list[]
-        can be thought of as rows
-    param_names: list[]
-        can be thought of as columns
-    """
-
-    def __init__(self):
-        self.params = []  # aka rows
-        self.param_names = []  # aka column names
-
-    @classmethod
-    def from_dict(cls, dictionary):
-        """
-        Creates an UniqAtomParams object, populates it with information from the input dictionary, then returns
-        the new object.
-
-        Parameters
-        ----------
-        dictionary: dict()
-            A dictionary containing the keys "params" and "param_names", where the value for "params" is parseable as
-            rows and the value for "param_names" contains the corresponding column data.
-
-        Returns
-        -------
-        A populated UniqAtomParams object
-        """
-        uap = UniqAtomParams()
-        uap.params = [row.copy() for row in dictionary["params"]]
-        uap.param_names = dictionary["param_names"].copy()
-        return uap
-
-    def get_indices_from_atom_params(self, atom_params):
-        """
-        Retrieves the indices of specific atom parameters in the UniqAtomParams object.
-
-        Parameters
-        ----------
-        atom_params: dict()
-            A dict with keys that correspond to the param names already in the UniqAtomParams object. The values are
-            lists that should all be the same size, and
-
-        Returns
-        -------
-        A list of indices corresponding to the order of parameters in the atom_params value lists that indicates the
-        index of that "row" of parameters in UniqAtomParams params.
-        """
-        nr_items = set([len(values) for key, values in atom_params.items()])
-        if len(nr_items) != 1:
-            raise RuntimeError(
-                f"all lists in atom_params must have same length, got {nr_items}"
-            )
-        if set(atom_params) != set(self.param_names):
-            msg = f"parameter names in atom_params differ from internal ones\n"
-            msg += f"  - in atom_params: {set(atom_params)}"
-            msg += f"  - internal: {set(self.param_names)}"
-            raise RuntimeError(msg)
-        nr_items = nr_items.pop()
-        param_idxs = []
-        for i in range(nr_items):
-            row = [atom_params[key][i] for key in self.param_names]
-            param_index = None
-            for j, existing_row in enumerate(self.params):
-                if row == existing_row:
-                    param_index = j
-                    break
-            param_idxs.append(param_index)
-        return param_idxs
-
-    def add_parameter(self, new_param_dict):
-        # remove None values to avoid a column with only Nones
-        new_param_dict = {k: v for k, v in new_param_dict.items() if v is not None}
-        incoming_keys = set(new_param_dict.keys())
-        existing_keys = set(self.param_names)
-        new_keys = incoming_keys.difference(existing_keys)
-        for new_key in new_keys:
-            self.param_names.append(new_key)
-            for row in self.params:
-                row.append(None)  # fill in empty "cell" in new "column"
-
-        new_row = []
-        for key in self.param_names:
-            value = new_param_dict.get(key, None)
-            new_row.append(value)
-
-        if len(new_keys) == 0:  # try to match with existing row
-            for index, row in enumerate(self.params):
-                if row == new_row:
-                    return index
-
-        # if we are here, we didn't match
-        new_row_index = len(self.params)
-        self.params.append(new_row)
-        return new_row_index
-
-    def add_molsetup(
-        self, molsetup, atom_params=None, add_atomic_nr=False, add_atom_type=False
-    ):
-        if "q" in molsetup.atom_params or "atom_type" in molsetup.atom_params:
-            msg = '"q" and "atom_type" found in molsetup.atom_params'
-            msg += " but are hard-coded to store molsetup.charge and"
-            msg += " molsetup.atom_type in the internal data structure"
-            raise RuntimeError(msg)
-        if atom_params is None:
-            atom_params = molsetup.atom_params
-        param_idxs = []
-        for atom_index, ignore in enumerate(molsetup.atom_ignore):
-            if ignore:
-                param_idx = None
-            else:
-                p = {k: v[atom_index] for (k, v) in molsetup.atom_params.items()}
-                if add_atomic_nr:
-                    if "atomic_nr" in p:
-                        raise RuntimeError(
-                            "trying to add atomic_nr but it's already in atom_params"
-                        )
-                    p["atomic_nr"] = molsetup.element[atom_index]
-                if add_atom_type:
-                    if "atom_type" in p:
-                        raise RuntimeError(
-                            "trying to add atom_type but it's already in atom_params"
-                        )
-                    p["atom_type"] = molsetup.atom_type[atom_index]
-                param_idx = self.add_parameter(p)
-            param_idxs.append(param_idx)
-        return param_idxs
 
 
 @dataclass

--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -21,7 +21,7 @@ from .utils import rdkitutils
 # region DEFAULT VALUES
 DEFAULT_PDBINFO = None
 DEFAULT_CHARGE = 0.0
-DEFAULT_ELEMENT = None
+DEFAULT_ATOMIC_NUM = None
 DEFAULT_ATOM_TYPE = None
 DEFAULT_IS_IGNORE = False
 DEFAULT_IS_CHIRAL = False
@@ -156,7 +156,7 @@ class UniqAtomParams:
                         raise RuntimeError(
                             "trying to add atomic_nr but it's already in atom_params"
                         )
-                    p["atomic_nr"] = molsetup.element[atom_index]
+                    p["atomic_nr"] = molsetup.atomic_num[atom_index]
                 if add_atom_type:
                     if "atom_type" in p:
                         raise RuntimeError(
@@ -171,7 +171,7 @@ class UniqAtomParams:
 class MoleculeSetup:
 
     # region CLASS CONSTANTS
-    PSEUDOATOM_ELEMENT = 0
+    PSEUDOATOM_ATOMIC_NUM = 0
     # endregion
 
     def __init__(self, name: str = None, is_sidechain: bool = False):
@@ -200,7 +200,7 @@ class MoleculeSetup:
         overwrite: bool = False,
         pdbinfo: str = DEFAULT_PDBINFO,
         charge: float = DEFAULT_CHARGE,
-        element: int = DEFAULT_ELEMENT,
+        atomic_num: int = DEFAULT_ATOMIC_NUM,
         atom_type: str = DEFAULT_ATOM_TYPE,
         is_ignore: bool = DEFAULT_IS_IGNORE,
         is_chiral: bool = DEFAULT_IS_CHIRAL,
@@ -217,7 +217,7 @@ class MoleculeSetup:
         overwrite: bool
         pdbinfo: str
         charge: float
-        element: int
+        atomic_num: int
         atom_type: str
         is_ignore: bool
         is_chiral: bool
@@ -251,7 +251,7 @@ class MoleculeSetup:
 
         # Creates and adds new atom to the atom list
         new_atom = Atom(
-            atom_index, pdbinfo, charge, element, atom_type, is_ignore, is_chiral, graph
+            atom_index, pdbinfo, charge, atomic_num, atom_type, is_ignore, is_chiral, graph
         )
         if atom_index < len(self.atoms):
             self.atoms[atom_index] = new_atom
@@ -292,7 +292,7 @@ class MoleculeSetup:
             pseudoatom_index,
             pdbinfo=pdbinfo,
             charge=charge,
-            element=self.PSEUDOATOM_ELEMENT,
+            atomic_num=self.PSEUDOATOM_ATOMIC_NUM,
             atom_type=atom_type,
             is_ignore=is_ignore,
             is_pseudo_atom=True,
@@ -440,12 +440,12 @@ class MoleculeSetup:
             )
         return self.atoms[atom_index].charge
 
-    def get_element(self, atom_index: int):
+    def get_atomic_num(self, atom_index: int):
         if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
             raise IndexError(
-                "GET_ELEMENT: provided atom index is out of range or is a dummy atom"
+                "GET_ATOMIC_NUM: provided atom index is out of range or is a dummy atom"
             )
-        return self.atoms[atom_index].element
+        return self.atoms[atom_index].atomic_num
 
     def get_atom_type(self, atom_index: int):
         if atom_index > len(self.atoms) or self.atoms[atom_index].is_dummy:
@@ -923,7 +923,7 @@ class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolBuild):
             self.add_atom(
                 idx,
                 coord=coords[idx],
-                element=a.GetAtomicNum(),
+                atomic_num=a.GetAtomicNum(),
                 charge=charges[idx],
                 atom_type=None,
                 pdbinfo=rdkitutils.getPdbInfoNoNull(a),
@@ -1013,7 +1013,7 @@ class OBMoleculeSetup(MoleculeSetup):
             self.add_atom(
                 a.GetIdx() - 1,
                 coord=np.asarray(obutils.getAtomCoords(a), dtype="float"),
-                element=a.GetAtomicNum(),
+                atomic_num=a.GetAtomicNum(),
                 charge=partial_charge,
                 atom_type=None,
                 pdbinfo=obutils.getPdbInfoNoNull(a),
@@ -1042,7 +1042,7 @@ class Atom:
     index: int
     pdbinfo: str = DEFAULT_PDBINFO
     charge: float = DEFAULT_CHARGE
-    element: int = DEFAULT_ELEMENT
+    atomic_num: int = DEFAULT_ATOMIC_NUM
     atom_type: str = DEFAULT_ATOM_TYPE
     is_ignore: bool = DEFAULT_IS_IGNORE
     is_chiral: bool = DEFAULT_IS_CHIRAL


### PR DESCRIPTION
Enables us to get rid of `bond_order` and `is_chiral` attributes in molsetups.