### PR TITLE
fix mk_prepare_receptor.py file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ mk_prepare_ligand.py\
 ## Reactive Docking
 
 ### 1. Prepare protein with waterkit
-Follow `wk_prepare_receptor.py` instructions and run with `--pdb`.
+Follow `mk_prepare_receptor.py` instructions and run with `--pdb`.
 The goal of this step is to perform essential fixes to the protein
 (such as missing atoms), to add hydrogens, and to follow the Amber
 naming scheme for atoms and residues, e.g., `HIE` or `HID`

--- a/example/reactive_adgpu/README.md
+++ b/example/reactive_adgpu/README.md
@@ -1,7 +1,7 @@
 This is a draft
 
 # 1. Prepare protein with waterkit
-Follow `wk_prepare_receptor.py` instructions and run with `--pdb`.
+Follow `mk_prepare_receptor.py` instructions and run with `--pdb`.
 The goal of this step is to perform essential fixes to the protein
 (such as missing atoms), to add hydrogens, and to follow the Amber
 naming scheme for atoms and residues, e.g., `HIE` or `HID`


### PR DESCRIPTION
I believe the file names in the document are incorrect. This PR fixes them.