### PR TITLE
flexible side chain recognition

### DIFF
--- a/meeko/rdkit_mol_create.py
+++ b/meeko/rdkit_mol_create.py
@@ -228,7 +228,7 @@ class RDKitMolCreate:
         candidate_resnames = cls.ambiguous_flexres_choices.get(resname, [resname])
         for resname in candidate_resnames:
             is_match = False
-            if resname not in cls.flexres[resname]["atom_names_in_smiles_order"]:
+            if resname not in cls.flexres:
                 continue
             atom_names_in_smiles_order = cls.flexres[resname]["atom_names_in_smiles_order"]
             h_to_parent_index = cls.flexres[resname]["h_to_parent_index"]


### PR DESCRIPTION
when using mk_export.py on a autodock-gpu dlg-file with flexible side-chains, 
the output-sdf file does not contain the side-chains. 

```python
flexres = {
    "CYS": {
        "smiles": "CCS",
        "atom_names_in_smiles_order": ["CA", "CB", "SG"],
        "h_to_parent_index": {"HG": 2},
    }
}
```
```python
if resname not in cls.flexres[resname]["atom_names_in_smiles_order"]:
    continue
```
this code checks if the resname (e.g. "CYS") is in "atom_names_in_smiles_order" of the entry "CYS" 

this if-statement will always be True, because "CYS" != "CA", "CB", "SG"

->  every resname in candidate_resnames will be skipped and...
```python
 RDKitMolCreate.from_pdbqt_mol(pdbqt_mol)
``` 
...will return None for every side-chain.