### PR TITLE
remove dropped attribute from molsetup.show()

### DIFF
--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -1304,10 +1304,6 @@ class MoleculeSetup:
             "-----+----------------------------+--------+---+----------+--------------- . . . "
         )
         print("  TOT CHARGE: %3.3f" % total_charge)
-        print("\n======[ DIRECTIONAL VECTORS ]==========")
-        for atom in self.atoms:
-            if atom.interaction_vector:
-                print("% 4d " % atom.index, atom.atom_type, end=" ")
 
         print("\n==============[ BONDS ]================")
         # For sanity users, we won't show those keys for now


### PR DESCRIPTION
The attribute `directional_vectors` has been removed from MoleculeSetup, but was still present in the `MoleculeSetup.show()` method.