### PR TITLE
Fix for PDBQT names with multimode_outdir

### DIFF
--- a/scripts/mk_prepare_ligand.py
+++ b/scripts/mk_prepare_ligand.py
@@ -609,7 +609,7 @@ if __name__ == "__main__":
                     add_index_map=args.add_index_map,
                 )
                 if success:
-                    output(pdbqt_string, output_filename.replace(".pdbqt",""), (suffix,))
+                    output(pdbqt_string, name, (suffix,))
                     if args.verbose:
                         molsetup.show()
                 else:


### PR DESCRIPTION
Reverts change from https://github.com/forlilab/Meeko/commit/5f2f1bdfbf662b4c21ff89104bd0eb73bff0044a