### PR TITLE
Bump actions/upload-artifact@v2 to v4

### DIFF
--- a/.github/workflows/pypi-build.yml
+++ b/.github/workflows/pypi-build.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         python setup.py sdist bdist_wheel
     - name: Upload artifacts for inspection
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: dist
         path: dist/*


### PR DESCRIPTION
The only change is to upgrade actions/upload-artifact@v2 to v4. The check passed for a test PR: https://github.com/rwxayheee/Meeko/actions/runs/11079306202
The artifact is here for reference: 
[dist.zip](https://github.com/user-attachments/files/17171644/dist.zip)