### PR TITLE
 Fix delete_residues in chorizo (polymer) and mk_prepare_receptor

### DIFF
--- a/meeko/linked_rdkit_chorizo.py
+++ b/meeko/linked_rdkit_chorizo.py
@@ -479,7 +479,7 @@ def _delete_residues(res_to_delete, raw_input_mols):
 
     Parameters
     ----------
-    res_to_delete: list (str)
+    res_to_delete: list (str) or None
         residue IDs to delete in format <chain>:<resnum><icode>
     raw_input_mols: dict (str -> RDKit mol)
         keys are residue IDs
@@ -490,6 +490,8 @@ def _delete_residues(res_to_delete, raw_input_mols):
     (modifies raw_input_mols in-place)
 
     """
+    if res_to_delete is None:
+        return
     missing = set()
     for res in res_to_delete:
         if res not in raw_input_mols:

--- a/test/json_serialization_test.py
+++ b/test/json_serialization_test.py
@@ -608,7 +608,6 @@ def check_residue_equality(decoded_obj: ChorizoResidue, starting_obj: ChorizoRes
     # Bools
     assert decoded_obj.is_flexres_atom == starting_obj.is_flexres_atom
     assert decoded_obj.is_movable == starting_obj.is_movable
-    assert decoded_obj.user_deleted == starting_obj.user_deleted
     return
 
 

--- a/test/linked_rdkit_chorizo_creation_test.py
+++ b/test/linked_rdkit_chorizo_creation_test.py
@@ -96,7 +96,6 @@ def test_AHHY_all_static_residues():
     assert len(chorizo.residues) == 4
     assert len(chorizo.get_ignored_residues()) == 0
     assert len(chorizo.get_valid_residues()) == 4
-    assert len(chorizo.get_user_deleted_residues()) == 0
     assert chorizo.residues["A:1"].residue_template_key == "ALA"
     assert chorizo.residues["A:2"].residue_template_key == "HID"
     assert chorizo.residues["A:3"].residue_template_key == "HIE"
@@ -148,7 +147,6 @@ def test_just_three_padded_mol():
     assert len(chorizo.residues) == 3
     assert len(chorizo.get_ignored_residues()) == 0
     assert len(chorizo.get_valid_residues()) == 3
-    assert len(chorizo.get_user_deleted_residues()) == 0
 
     assert chorizo.residues[":15"].residue_template_key == "NMET"
     assert chorizo.residues[":16"].residue_template_key == "SER"
@@ -189,8 +187,6 @@ def test_AHHY_mutate_residues():
     assert len(chorizo.residues) == 4
     assert len(chorizo.get_ignored_residues()) == 0
     assert len(chorizo.get_valid_residues()) == 3
-    assert len(chorizo.get_user_deleted_residues()) == 1
-    assert chorizo.residues["A:4"].user_deleted
 
     assert chorizo.residues["A:1"].residue_template_key == "ALA"
     assert chorizo.residues["A:2"].residue_template_key == "HIP"
@@ -220,7 +216,6 @@ def test_residue_missing_atoms():
         blunt_ends=[("A:1", 0), ("A:1", 2)],
     )
     assert len(chorizo.get_valid_residues()) == 0
-    assert len(chorizo.get_user_deleted_residues()) == 0
     assert len(chorizo.residues) == 1
     assert len(chorizo.get_ignored_residues()) == 1
 

--- a/test/linked_rdkit_chorizo_creation_test.py
+++ b/test/linked_rdkit_chorizo_creation_test.py
@@ -184,7 +184,7 @@ def test_AHHY_mutate_residues():
         set_template=set_template,
         blunt_ends=[("A:1", 0)],
     )
-    assert len(chorizo.residues) == 4
+    assert len(chorizo.residues) == 3
     assert len(chorizo.get_ignored_residues()) == 0
     assert len(chorizo.get_valid_residues()) == 3
 


### PR DESCRIPTION
The list of residue IDs to delete is no longer passed to the `__init__` of the chorizo object. Instead, it lives only on the constructors `from_prody` and `from_pdb_string`. Then, the raw molecules passed to the `__init__` of the chorizo no longer contains deleted residues. In `mk_prepare_receptor`, deleted_residues are specified using the same syntax as flexres, e.g. `--delete_residues A:278`.