### PR TITLE
Fixing NME in #180

### DIFF
--- a/meeko/data/residue_chem_templates.json
+++ b/meeko/data/residue_chem_templates.json
@@ -44,6 +44,10 @@
 	    "rxn_smarts": "[C:1](=[O:2])[C:3][N:4]>>[C:1](=[O:2])[C:3][N:4][C:11](=[O:12])[C:13]",
 	    "adjacent_res_smarts": "[C:11](=[O:12])[C:13][N]"
 	},
+	"NME-N-term": {
+	    "rxn_smarts": "[C:3][N:4]>>[C:3][N:4][C:11](=[O:12])[C:13]",
+	    "adjacent_res_smarts": "[C:11](=[O:12])[C:13][N]"
+	},
 	"C-term": {
 	    "rxn_smarts": "[C:1](=[O:2])[C:3][N:4]>>[C:11][N:12][C:1](=[O:2])[C:3][N:4]",
 	    "adjacent_res_smarts": "[C](=O)[C:11][N:12]"
@@ -58,7 +62,7 @@
     	"NME": {
     	    "smiles": "C([H])([H])([H])N[H]",
     	    "atom_name": ["CH3", "HH31", "HH32", "HH33", "N", "H"],
-    	    "link_labels": {"4": "N-term"}
+    	    "link_labels": {"4": "NME-N-term"}
     	},
     	"ACE": {
     	    "smiles": "C(=O)C([H])([H])[H]",

--- a/meeko/data/residue_chem_templates.json
+++ b/meeko/data/residue_chem_templates.json
@@ -5,7 +5,6 @@
 	"C": ["C", "C-5endPO4", "C-5endOH"],
 	"U": ["U", "U-5endPO4"],
 	"HIS": ["HIE", "HID", "HIP", "NHIE", "NHID", "NHIP", "CHIE", "CHID", "CHIP"],
-	"TYR": ["TYR", "NTYR", "CTYR"],
     	"CYS": ["CYS", "CYX", "CYX-", "NCYS", "NCYX", "NCYX-", "CCYS", "CCYX", "CCYX-"],
     	"CYX": [       "CYX", "CYX-",         "NCYX", "NCYX-",         "CCYX", "CCYX-"],
     	"CYM": [              "CYX-",                 "NCYX-",                 "CCYX-"],
@@ -42,15 +41,15 @@
 	},
 	"N-term": {
 	    "rxn_smarts": "[C:1](=[O:2])[C:3][N:4]>>[C:1](=[O:2])[C:3][N:4][C:11](=[O:12])[C:13]",
-	    "adjacent_res_smarts": "[C:11](=[O:12])[C:13][N]"
+	    "adjacent_res_smarts": "[CX3h1:11](=[O:12])[C:13]"
 	},
 	"NME-N-term": {
 	    "rxn_smarts": "[C:3][N:4]>>[C:3][N:4][C:11](=[O:12])[C:13]",
-	    "adjacent_res_smarts": "[C:11](=[O:12])[C:13][N]"
+	    "adjacent_res_smarts": "[CX3h1:11](=[O:12])[C:13]"
 	},
 	"C-term": {
 	    "rxn_smarts": "[C:1](=[O:2])[C:3][N:4]>>[C:11][N:12][C:1](=[O:2])[C:3][N:4]",
-	    "adjacent_res_smarts": "[C](=O)[C:11][N:12]"
+	    "adjacent_res_smarts": "[C:11][NX3h1:12]"
 	},
 	"dissulfide": {
 	    "rxn_smarts": "[C:1][S:2]>>[C:1][S:2][S:11][C:12]",

--- a/meeko/linked_rdkit_chorizo.py
+++ b/meeko/linked_rdkit_chorizo.py
@@ -474,6 +474,36 @@ def update_H_positions(mol: Chem.Mol, indices_to_update: list[int]) -> None:
 
     return
 
+def _delete_residues(res_to_delete, raw_input_mols):
+    """
+
+    Parameters
+    ----------
+    res_to_delete: list (str) or None
+        residue IDs to delete in format <chain>:<resnum><icode>
+    raw_input_mols: dict (str -> RDKit mol)
+        keys are residue IDs
+
+    Returns
+    -------
+    None
+    (modifies raw_input_mols in-place)
+
+    """
+    if res_to_delete is None:
+        return
+    missing = set()
+    for res in res_to_delete:
+        if res not in raw_input_mols:
+            missing.add(res)
+        raw_input_mols.pop(res)
+    if len(missing) > 0:
+        msg = "can't find the following residues to delete: " + " ".join(missing)
+        raise ValueError(msg)
+    return
+
+
+
 
 class ResidueChemTemplates:
     """Holds template data required to initialize LinkedRDKitChorizo
@@ -584,7 +614,6 @@ class LinkedRDKitChorizo:
     ----------
     residues: dict (string -> ChorizoResidue) #TODO: figure out exact SciPy standard for dictionary key/value notation
     termini: dict (string (representing residue id) -> string (representing what we want the capping to look like))
-    deleted_residues: list (string) residue ids to be deleted
     mutate_res_dict: dict (string (representing starting residue id) -> string (representing the desired mutated id))
     res_templates: dict (string -> dict (rdkit_mol and atom_data))
     ambiguous:
@@ -599,7 +628,6 @@ class LinkedRDKitChorizo:
         residue_chem_templates: ResidueChemTemplates,
         mk_prep=None,
         set_template: dict[str, str] = None,
-        residues_to_delete: list[str] = None,
         blunt_ends: list[tuple[str, int]] = None,
     ):
         """
@@ -617,8 +645,6 @@ class LinkedRDKitChorizo:
             An instance of the MoleculePreparation class to parameterize the padded molecules.
         set_template: dict (string -> string)
             A dict mapping residue IDs in the format <chain>:<resnum> such as "A:42" to ResidueTemplate instances.
-        residues_to_delete: list (string)
-            List of residue IDs (e.g.; "A:42") to mark as ignored
         blunt_ends: list (tuple (string, int))
             A list of tuples where each tuple is residue IDs and 0-based atom index, e.g.; ("A:42", 0)
 
@@ -632,7 +658,6 @@ class LinkedRDKitChorizo:
         """
 
         # TODO simplify SMARTS for adjacent res in padders
-        # TODO deleted residues up from init into classmethod constructors
 
         if type(raw_input_mols) != dict:
             msg = f"expected raw_input_mols to be dict, got {type(raw_input_mols)}"
@@ -678,11 +703,6 @@ class LinkedRDKitChorizo:
             bonds,
             blunt_ends,
         )
-
-        # TODO integrate with mk_prepare_receptor.py (former suggested_mutations)
-        if residues_to_delete is None:
-            residues_to_delete = ()  # self._delete_residues expects an iterator
-        self._delete_residues(residues_to_delete, self.residues)
 
         _bonds = {}
         for key, bond in bonds.items():
@@ -738,6 +758,7 @@ class LinkedRDKitChorizo:
         """
 
         raw_input_mols = cls._pdb_to_residue_mols(pdb_string)
+        _delete_residues(residues_to_delete, raw_input_mols)
         bonds = find_inter_mols_bonds(raw_input_mols)
         if bonds_to_delete is not None:
             for res1, res2 in bonds_to_delete:
@@ -751,7 +772,6 @@ class LinkedRDKitChorizo:
             chem_templates,
             mk_prep,
             set_template,
-            residues_to_delete,
             blunt_ends,
         )
         if not allow_bad_res and len(chorizo.get_ignored_residues()):
@@ -788,6 +808,7 @@ class LinkedRDKitChorizo:
 
         """
         raw_input_mols = cls._prody_to_residue_mols(prody_obj)
+        _delete_residues(residues_to_delete, raw_input_mols)
         bonds = find_inter_mols_bonds(raw_input_mols)
         if bonds_to_delete is not None:
             for res1, res2 in bonds_to_delete:
@@ -801,7 +822,6 @@ class LinkedRDKitChorizo:
             chem_templates,
             mk_prep,
             set_template,
-            residues_to_delete,
             blunt_ends,
         )
         if not allow_bad_res and len(chorizo.get_ignored_residues()):
@@ -1236,30 +1256,23 @@ class LinkedRDKitChorizo:
                 atom.GetIdx(): atom.GetIdx() for atom in padded_mol.GetAtoms()
             }
             for atom_index, link_label in residue.link_labels.items():
-                adjacent_mol, adjacent_resname = [None, None]
+                adjacent_mol = None
                 adjacent_atom_index = None
                 for (r1_id, r2_id), (i1, i2) in bonds.items():
                     if r1_id == residue_id and i1 == atom_index:
-                        adjacent_mol, adjacent_resname = [residues[r2_id].rdkit_mol, residues[r2_id].input_resname]
+                        adjacent_mol = residues[r2_id].rdkit_mol
                         adjacent_atom_index = i2
                         bond_use_count[(r1_id, r2_id)] += 1
                         break
                     elif r2_id == residue_id and i2 == atom_index:
-                        adjacent_mol, adjacent_resname = [residues[r1_id].rdkit_mol, residues[r1_id].input_resname]
+                        adjacent_mol = residues[r1_id].rdkit_mol
                         adjacent_atom_index = i1
                         bond_use_count[(r1_id, r2_id)] += 1
                         break
-                if adjacent_resname == 'NME': 
-                    capping_rxn_smarts = "[C:1](=[O:2])>>[C:11][N:12][C:1](=[O:2])"
-                    capping_adjacent_res_smarts = "[C:11][N:12]"
-                    capping = ResiduePadder(capping_rxn_smarts, capping_adjacent_res_smarts)
-                    padded_mol, mapidx = capping(
+
+                padded_mol, mapidx = padders[link_label](
                     padded_mol, adjacent_mol, atom_index, adjacent_atom_index
                 )
-                else:
-                    padded_mol, mapidx = padders[link_label](
-                        padded_mol, adjacent_mol, atom_index, adjacent_atom_index
-                    )
 
                 tmp = {}
                 for i, j in enumerate(mapidx):
@@ -1306,31 +1319,6 @@ class LinkedRDKitChorizo:
         if len(err_msg):
             raise RuntimeError(err_msg)
         return padded_mols
-
-    @staticmethod
-    def _delete_residues(query_res, residues):
-        """
-
-        Parameters
-        ----------
-        query_res
-        residues
-
-        Returns
-        -------
-
-        """
-        missing = set()
-        for res in query_res:
-            if res not in residues:
-                missing.add(res)
-            elif residues[
-                res
-            ]:  # is not None: # expecting None if templates didn't match
-                residues[res].user_deleted = True
-        if len(missing) > 0:
-            msg = "can't find the following residues to delete: " + " ".join(missing)
-            raise ValueError(msg)
 
     def flexibilize_sidechain(self, residue_id, mk_prep):
         """
@@ -1534,12 +1522,7 @@ class LinkedRDKitChorizo:
         atom_count = 0
         pdb_line = "{:6s}{:5d} {:^4s} {:3s} {:1s}{:4d}{:1s}   {:8.3f}{:8.3f}{:8.3f}                       {:2s} "
         pdb_line += pathlib.os.linesep
-        for res_id in self.residues:
-            if (
-                self.residues[res_id].user_deleted
-                or self.residues[res_id].rdkit_mol is None
-            ):
-                continue
+        for res_id in self.get_valid_residues():
             resmol = self.residues[res_id].rdkit_mol
             if use_modified_coords and self.residues[res_id].molsetup is not None:
                 molsetup = self.residues[res_id].molsetup
@@ -1644,21 +1627,11 @@ class LinkedRDKitChorizo:
 
     # The following functions return filtered dictionaries of residues based on the value of residue flags.
     # region Filtering Residues
-    def get_user_deleted_residues(self):
-        return {k: v for k, v in self.residues.items() if v.user_deleted}
-
-    def get_non_user_deleted_residues(self):
-        return {k: v for k, v in self.residues.items() if not v.user_deleted}
-
     def get_ignored_residues(self):
         return {k: v for k, v in self.residues.items() if v.rdkit_mol is None}
 
-    def get_not_ignored_residues(self):
-        return {k: v for k, v in self.residues.items() if not v.rdkit_mol is not None}
-
-    # TODO: rename this
     def get_valid_residues(self):
-        return {k: v for k, v in self.residues.items() if v.is_valid_residue()}
+        return {k: v for k, v in self.residues.items() if v.rdkit_mol is not None}
 
     # endregion
 
@@ -1807,11 +1780,7 @@ class ChorizoResidue:
         self.molsetup = None
         self.molsetup_mapidx = None
         self.is_flexres_atom = None  # Check about these data types/Do we want the default to be None or empty
-
-        # flags
-        # NOTE no longer using ignore_residue, checking if rdkit_mol == None instead
         self.is_movable = False
-        self.user_deleted = False
 
     def set_atom_names(self, atom_names_list):
         """
@@ -1859,17 +1828,6 @@ class ChorizoResidue:
         """
         residue = json.loads(json_string, object_hook=cls.chorizo_residue_json_decoder)
         return residue
-
-    def is_valid_residue(self) -> bool:
-        """
-        Returns true if the residue is not marked as deleted by a user and has not been marked as a residue to
-        ignore
-
-        Returns
-        -------
-        bool
-        """
-        return self.rdkit_mol is not None and not self.user_deleted
 
 
 class ResiduePadder:
@@ -2156,7 +2114,6 @@ class ChorizoResidueEncoder(json.JSONEncoder):
                 "molsetup": molsetup_json,
                 "is_flexres_atom": obj.is_flexres_atom,
                 "is_movable": obj.is_movable,
-                "user_deleted": obj.user_deleted,
                 "molsetup_mapidx": obj.molsetup_mapidx,
             }
         return json.JSONEncoder.default(self, obj)
@@ -2340,7 +2297,6 @@ def chorizo_residue_json_decoder(obj: dict):
         "molsetup",
         "is_flexres_atom",
         "is_movable",
-        "user_deleted",
         "molsetup_mapidx",
     }
 
@@ -2376,7 +2332,6 @@ def chorizo_residue_json_decoder(obj: dict):
     # boolean values
     residue.is_flexres_atom = obj["is_flexres_atom"]
     residue.is_movable = obj["is_movable"]
-    residue.user_deleted = obj["user_deleted"]
 
     return residue
 

--- a/test/json_serialization_test.py
+++ b/test/json_serialization_test.py
@@ -608,7 +608,6 @@ def check_residue_equality(decoded_obj: ChorizoResidue, starting_obj: ChorizoRes
     # Bools
     assert decoded_obj.is_flexres_atom == starting_obj.is_flexres_atom
     assert decoded_obj.is_movable == starting_obj.is_movable
-    assert decoded_obj.user_deleted == starting_obj.user_deleted
     return
 
 

--- a/test/linked_rdkit_chorizo_creation_test.py
+++ b/test/linked_rdkit_chorizo_creation_test.py
@@ -96,7 +96,6 @@ def test_AHHY_all_static_residues():
     assert len(chorizo.residues) == 4
     assert len(chorizo.get_ignored_residues()) == 0
     assert len(chorizo.get_valid_residues()) == 4
-    assert len(chorizo.get_user_deleted_residues()) == 0
     assert chorizo.residues["A:1"].residue_template_key == "ALA"
     assert chorizo.residues["A:2"].residue_template_key == "HID"
     assert chorizo.residues["A:3"].residue_template_key == "HIE"
@@ -148,7 +147,6 @@ def test_just_three_padded_mol():
     assert len(chorizo.residues) == 3
     assert len(chorizo.get_ignored_residues()) == 0
     assert len(chorizo.get_valid_residues()) == 3
-    assert len(chorizo.get_user_deleted_residues()) == 0
 
     assert chorizo.residues[":15"].residue_template_key == "NMET"
     assert chorizo.residues[":16"].residue_template_key == "SER"
@@ -186,11 +184,8 @@ def test_AHHY_mutate_residues():
         set_template=set_template,
         blunt_ends=[("A:1", 0)],
     )
-    assert len(chorizo.residues) == 4
     assert len(chorizo.get_ignored_residues()) == 0
     assert len(chorizo.get_valid_residues()) == 3
-    assert len(chorizo.get_user_deleted_residues()) == 1
-    assert chorizo.residues["A:4"].user_deleted
 
     assert chorizo.residues["A:1"].residue_template_key == "ALA"
     assert chorizo.residues["A:2"].residue_template_key == "HIP"
@@ -220,7 +215,6 @@ def test_residue_missing_atoms():
         blunt_ends=[("A:1", 0), ("A:1", 2)],
     )
     assert len(chorizo.get_valid_residues()) == 0
-    assert len(chorizo.get_user_deleted_residues()) == 0
     assert len(chorizo.residues) == 1
     assert len(chorizo.get_ignored_residues()) == 1
 


### PR DESCRIPTION
This is a working version with minimal fixes for NME in #180 without changing the data structure of chem templates. 

Specifically for the following two conditions, some adaptions are made to "rxn_smarts" and "adjacent_res_smarts": 
(1) Residue -(C-term)-> NME for the making of padded **NME**
and
(2) Residue <-(N-term)- NME for the making of padded Residue 

In condition (2), NME is being padded, but it doesn't have enough atoms as required by the default reaction: 
```
"N-term": {
	    "rxn_smarts": "[C:1](=[O:2])[C:3][N:4]>>[C:1](=[O:2])[C:3][N:4][C:11](=[O:12])[C:13]",
	    "adjacent_res_smarts": "[C:11](=[O:12])[C:13][N]"
	},
```
Therefore, a new link label pointing to a different reaction is needed. 

In condition (1), NME is the next residue (**adjacent_mol**). https://github.com/rwxayheee/Meeko/commit/a242725ce16596c57a434f3a41d24896ac7a53dd has NME as a hardcoded exception. 

In the long term, if nonstandard residues with modified backbones are to be incorporated, it may be helpful to determine the best reaction by (the input resnames, or the categories of) both the target residue and the adjacent residue. 

Some refactoring of chem templates is underway to categorize residues and reactions, to handle padder building (and maybe also intermol bond perception) conditionally. If there are any updates they will be added to this PR. 