### PR TITLE
Small fixes for ligand preparation

### DIFF
--- a/meeko/rdkit_mol_create.py
+++ b/meeko/rdkit_mol_create.py
@@ -471,6 +471,8 @@ class RDKitMolCreate:
             if len(pdbqt_mol._pose_data[key_in_pdbqt]) == nr_poses:
                 available_properties[key_in_mol] = key_in_pdbqt
         mol_level_data = json.loads(combined_mol.GetProp("meeko"))
+        if pdbqt_mol.name is not None:
+            combined_mol.SetProp("_Name", pdbqt_mol.name)
         for conformer in combined_mol.GetConformers():
             i = conformer.GetId()
             j = pose_idxs[i]

--- a/scripts/mk_export.py
+++ b/scripts/mk_export.py
@@ -56,7 +56,8 @@ for filename in docking_results_filenames:
     else:
         with open(filename) as f:
             string = f.read()
-    pdbqt_mol = PDBQTMolecule(string, is_dlg=is_dlg, skip_typing=True)
+    pdbqt_mol = PDBQTMolecule(string, name = os.path.splitext(os.path.basename(filename))[0], 
+                              is_dlg=is_dlg, skip_typing=True)
 
     output_string, failures = RDKitMolCreate.write_sd_string(
             pdbqt_mol, only_cluster_leads=only_cluster_leads)

--- a/scripts/mk_prepare_ligand.py
+++ b/scripts/mk_prepare_ligand.py
@@ -646,7 +646,7 @@ if __name__ == "__main__":
     # Determine if exit code should be non-zero based on processing results
     if output.num_files_written == 0:
         print("No PDBQT files were written due to errors!")
-        sys.exit(1)  # full failure
+        sys.exit(3)  # full failure
     elif input_mol_with_failure > 0:
         print("Some molecules encountered errors!")
-        sys.exit(2)  # partial failure
+        sys.exit(4)  # partial failure

--- a/scripts/mk_prepare_ligand.py
+++ b/scripts/mk_prepare_ligand.py
@@ -393,6 +393,8 @@ class Output:
             self.multimol_output_dir,
             f"{prefix}{self.tarf_index:07d}.tar.gz"
         )
+        if self.tarf is not None:
+            self.tarf.close()
         tarf = tarfile.open(tgz_path, "w:gz")
         return tarf
 
@@ -438,7 +440,8 @@ class Output:
                 self._add_to_tar(pdbqt_string, name)
             else:
                 fpath = os.path.join(self.multimol_output_dir, name + ".pdbqt")
-                print(pdbqt_string, end="", file=open(fpath, "w"))
+                with open(fpath, "w") as f:
+                    print(pdbqt_string, end="", file=f)
             self.num_files_written += 1
 
         elif self.redirect_stdout:
@@ -448,7 +451,8 @@ class Output:
                 filename = "%s.pdbqt" % name
             else:
                 filename = self.output_filename
-            print(pdbqt_string, end="", file=open(filename, "w"))
+            with open(filename, "w") as f:
+                print(pdbqt_string, end="", file=f)
             self.num_files_written += 1
 
     def _mkdir(self, multimol_output_dir):

--- a/scripts/mk_prepare_ligand.py
+++ b/scripts/mk_prepare_ligand.py
@@ -556,15 +556,6 @@ if __name__ == "__main__":
             )
             break
 
-        if args.name_from_prop is not None:
-            if mol.HasProp(args.name_from_prop):
-                name = mol.GetProp(args.name_from_prop)
-            else:
-                continue  # TODO log this event
-        else:
-            name = mol.GetProp("_Name")
-        is_after_first = True
-
         # check that molecule was successfully loaded
         if backend == "rdkit":
             is_valid = mol is not None
@@ -573,6 +564,15 @@ if __name__ == "__main__":
             continue
 
         this_mol_had_failure = False
+
+        if args.name_from_prop is not None:
+            if mol.HasProp(args.name_from_prop):
+                name = mol.GetProp(args.name_from_prop)
+            else:
+                continue  # TODO log this event
+        else:
+            name = mol.GetProp("_Name")
+        is_after_first = True
 
         if is_covalent:
             for cov_lig in covalent_builder.process(

--- a/scripts/mk_prepare_ligand.py
+++ b/scripts/mk_prepare_ligand.py
@@ -627,15 +627,26 @@ if __name__ == "__main__":
 
         input_mol_with_failure += int(this_mol_had_failure)
 
+    # Close the last tarf opened
     if output.tarf is not None:
         output.tarf.close()
 
+    # Print final status
+    print(
+        "Input molecules processed: %d, skipped: %d"
+        % (output.counter, input_mol_skipped)
+    )
+    print("PDBQT files written: %d" % (output.num_files_written))
+    print("PDBQT files not written due to error: %d" % (nr_failures))
+    print("Input molecules with errors: %d" % (input_mol_with_failure))
     if output.is_multimol:
-        print(
-            "Input molecules processed: %d, skipped: %d"
-            % (output.counter, input_mol_skipped)
-        )
-        print("PDBQT files written: %d" % (output.num_files_written))
-        print("PDBQT files not written due to error: %d" % (nr_failures))
-        print("Input molecules with errors: %d" % (input_mol_with_failure))
+        # would be None if not is_multimol
         print(output.get_duplicates_info_string())
+
+    # Determine if exit code should be non-zero based on processing results
+    if output.num_files_written == 0:
+        print("No PDBQT files were written due to errors!")
+        sys.exit(1)  # full failure
+    elif input_mol_with_failure > 0:
+        print("Some molecules encountered errors!")
+        sys.exit(2)  # partial failure

--- a/scripts/mk_prepare_ligand.py
+++ b/scripts/mk_prepare_ligand.py
@@ -413,7 +413,7 @@ class Output:
             self.duplicate_names.add(name)
         self.visited_names.add(name)
         if self.multimol_prefix is not None:
-            name = "%s-%d" % (args.multimol_prefix, self.counter)
+            name = "%s-%d" % (self.multimol_prefix, self.counter)
         for suffix in suffixes:
             if suffix is not None and len(suffix) > 0:
                 name += "_" + suffix


### PR DESCRIPTION
This PR has some small fixes related to ligand preparation, aiming to close the following tickets: 

- Include the fix suggested by @proline8314 in #142. 
- As suggested in #64 and @diogomart , mk_prepare_ligand.py will return non-zero exit codes if it fails to generate some (or any at all) PDBQT files for some molecules. 
- To address the request to preserve the ligand name in #50, mk_export.py will perceive the ligand name from the source (PDBQT, DLG) filename as usual and write to SDF file. No change in REMARK lines.
- Very small additional protection to mk_prepare_ligand.py: ensure opened file closure; check if mol is None before calling mol.GetProp and such