### PR TITLE
small fixes to guard against KeyError and UnboundLocalError

### DIFF
--- a/meeko/linked_rdkit_chorizo.py
+++ b/meeko/linked_rdkit_chorizo.py
@@ -178,6 +178,12 @@ def find_inter_mols_bonds(mols_dict):
             for a2 in mols_dict[keys[j]][0].GetAtoms():
                 vec = p1[a1.GetIdx()] - p2[a2.GetIdx()]
                 distsqr = np.dot(vec, vec)
+
+                # check if atom has implemented covalent radius
+                for atom in [a1, a2]:
+                    if atom.GetAtomicNum() not in covalent_radius:
+                        raise RuntimeError(f"Element {periodic_table.GetElementSymbol(atom.GetAtomicNum())} doesn't have an implemented covalent radius, which was required for the perception of intermolecular bonds. ")
+                    
                 cov_dist = (
                     covalent_radius[a1.GetAtomicNum()]
                     + covalent_radius[a2.GetAtomicNum()]
@@ -1127,6 +1133,8 @@ class LinkedRDKitChorizo:
             elif len(ambiguous[input_resname]) == 1:
                 template_key = ambiguous[input_resname][0]
                 template = residue_templates[template_key]
+                candidate_template_keys = [template_key]
+                candidate_templates = [template]
             else:
                 candidate_template_keys = []
                 candidate_templates = []


### PR DESCRIPTION
The PR has two small fixes to protect from KeyError and UnboundLocalError

1- When an unsupported element is up for intermol bond evaluation, and it doesn't have an implemented covalent radius (which won't have an AutoDock atom type either)

```
(mk_dev) amyhe@Amys-MBP Suraj % mk_prepare_receptor.py --pdb 3owz.pdb -o 3owz --add_templates additional_templates.json --skip_gpf --allow_bad_res 
/Users/amyhe/micromamba/envs/mk_dev/bin/mk_prepare_receptor.py:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  __import__('pkg_resources').require('meeko==0.6.0a3')
templates=<meeko.linked_rdkit_chorizo.ResidueChemTemplates object at 0x147c150f0>
Traceback (most recent call last):
  File "/Users/amyhe/micromamba/envs/mk_dev/bin/mk_prepare_receptor.py", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/Users/amyhe/Desktop/0_forks/Meeko/scripts/mk_prepare_receptor.py", line 457, in <module>
    chorizo = LinkedRDKitChorizo.from_pdb_string(
  File "/Users/amyhe/Desktop/0_forks/Meeko/meeko/linked_rdkit_chorizo.py", line 767, in from_pdb_string
    bonds = find_inter_mols_bonds(raw_input_mols)
  File "/Users/amyhe/Desktop/0_forks/Meeko/meeko/linked_rdkit_chorizo.py", line 183, in find_inter_mols_bonds
    + covalent_radius[a2.GetAtomicNum()]
KeyError: 77
```


2- When a residue name has just a single template in ambiguous dict
```
(mk_dev) amyhe@Amys-MBP Suraj % mk_prepare_receptor.py --pdb 3owz_noIRI.pdb -o 3owz_noIRI --add_templates additional_templates.json --skip_gpf --allow_bad_res
/Users/amyhe/micromamba/envs/mk_dev/bin/mk_prepare_receptor.py:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  __import__('pkg_resources').require('meeko==0.6.0a3')
templates=<meeko.linked_rdkit_chorizo.ResidueChemTemplates object at 0x16bfe90f0>
Traceback (most recent call last):
  File "/Users/amyhe/micromamba/envs/mk_dev/bin/mk_prepare_receptor.py", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/Users/amyhe/Desktop/0_forks/Meeko/scripts/mk_prepare_receptor.py", line 457, in <module>
    chorizo = LinkedRDKitChorizo.from_pdb_string(
  File "/Users/amyhe/Desktop/0_forks/Meeko/meeko/linked_rdkit_chorizo.py", line 774, in from_pdb_string
    chorizo = cls(
  File "/Users/amyhe/Desktop/0_forks/Meeko/meeko/linked_rdkit_chorizo.py", line 677, in __init__
    self.residues, self.log = self._get_residues(
  File "/Users/amyhe/Desktop/0_forks/Meeko/meeko/linked_rdkit_chorizo.py", line 1157, in _get_residues
    for index, template in enumerate(candidate_templates):
UnboundLocalError: local variable 'candidate_templates' referenced before assignment
```

because of 
```
    "ambiguous": {
        "GTP": ["GTP5p"],
        "GDP": ["GDP5p"],
        "CCC": ["CCC3"],
        "A23": ["A233"],
        "23G": ["23G3"]
    },
```
This might become a little more common if in future the ambiguous dict is also used to map the force field residue name with our internal template name, which can be a CCD component name or a name with suffix. 