### PR TITLE
fix typo in _aux_altloc_mol_build

### DIFF
--- a/meeko/utils/rdkitutils.py
+++ b/meeko/utils/rdkitutils.py
@@ -184,13 +184,13 @@ def _aux_altloc_mol_build(atom_field_list, requested_altloc, allowed_altloc):
     elif requested_altloc and requested_altloc not in mols_dict:
         pdbmol = None
         missed_altloc = True
-        needed_altoc = False
+        needed_altloc = False
     elif allowed_altloc and allowed_altloc in mols_dict:
         pdbmol, idx_to_rdkit = mols_dict[allowed_altloc]
     elif has_altloc and allowed_altloc not in mols_dict:
         pdbmol = None
-        needed_altloc = True
-        missed_altloc = False
+        missed_altloc = True
+        needed_altloc = False
     elif not has_altloc and requested_altloc is None:
         pdbmol, idx_to_rdkit = mols_dict[None]
     else:

--- a/scripts/mk_prepare_receptor.py
+++ b/scripts/mk_prepare_receptor.py
@@ -478,7 +478,7 @@ for res_id in reactive_flexres:
         if input_resname in reactive_atom:
             reactive_flexres_name[res_id] = reactive_atom[input_resname]
         else:
-            print("no default reactive name for %s, " % resname)
+            print("no default reactive name for %s, " % input_resname)
             print("use --reactive_name or --reactive_name_specific" + os_linesep)
             sys.exit(2)
 


### PR DESCRIPTION
Fixed small variable name typo in _aux_altloc_mol_build

Also flipped missed and needed here
https://github.com/forlilab/Meeko/blob/8257379fdac56ab27b9a17f609ea443acf2111a0/meeko/utils/rdkitutils.py#L190-L193

