### PR TITLE
add help print to mk_prepare_receptor

### DIFF
--- a/scripts/mk_prepare_receptor.py
+++ b/scripts/mk_prepare_receptor.py
@@ -496,7 +496,6 @@ if args.add_templates is not None:
         sys.exit(2)
 templates = ResidueChemTemplates.from_dict(res_chem_templates)
 
-print(f"{templates=}")
 # create chorizos
 if args.read_with_prody is not None:
     if not _got_prody:
@@ -930,6 +929,15 @@ if written_files_log["filename"]:
     line = "%%%ds <-- " % longest_fn + "%s"
     for fn, desc in zip(written_files_log["filename"], written_files_log["description"]):
         print(line % (fn, desc))
+    if (
+        args.output_basename is not None and
+        args.output_basename.endswith(".pdbqt") and
+        args.write_pdbqt is None
+    ):
+        print()
+        print("PDBQT files were NOT written. Use -p/--write_pdbqt for that.")
+        print("Note that -o/--output_basename just sets a default for --write flags")
+        print()
 else:
     print()
     print()


### PR DESCRIPTION
Adds help message for users who are used to `-o` flag in mk_prepare_receptor in older versions. Before v0.6.0, `-o` sets the PDBQT output filename, but in v0.6.0, it sets a default output basename that `--write` options rely on.

If someone runs `-o output.pdbqt -j`, the `-j` flag triggers writing a file named "output.pdbqt.json", but no PDBQT files are written. The added help message, shown below, is printed if the output basename ends with ".pdbqt" and `--write_pdbqt` was not used.

```
PDBQT files were NOT written. Use -p/--write_pdbqt for that.
Note that -o/--output_basename just sets a default for --write flags
```