### PR TITLE
re-implement residue.is_flexres_atom, and minor fixes

### DIFF
--- a/meeko/linked_rdkit_chorizo.py
+++ b/meeko/linked_rdkit_chorizo.py
@@ -1423,6 +1423,22 @@ class LinkedRDKitChorizo:
             residue.molsetup,
             root_atom_index=link_atoms[0],
         )
+
+        molsetup = residue.molsetup
+        is_rigid_atom = [False for _ in molsetup.atoms]
+        graph = molsetup.flexibility_model["rigid_body_graph"]
+        root_body_idx = molsetup.flexibility_model["root"]
+        conn = molsetup.flexibility_model["rigid_body_connectivity"]
+        rigid_index_by_atom = molsetup.flexibility_model["rigid_index_by_atom"]
+        # from the root, use only the atom that is bonded to the only rotatable bond
+        print(graph)
+        print(rigid_index_by_atom)
+        print(len(rigid_index_by_atom))
+        for other_body_idx in graph[root_body_idx]:
+            root_link_atom_idx = conn[(root_body_idx, other_body_idx)][0]
+            for atom_idx, body_idx in rigid_index_by_atom.items():
+                if body_idx != root_body_idx or atom_idx == root_link_atom_idx:
+                    residue.is_flexres_atom[atom_idx] = True
         return
 
     @staticmethod

--- a/scripts/mk_prepare_receptor.py
+++ b/scripts/mk_prepare_receptor.py
@@ -674,8 +674,9 @@ if args.write_pdb is not None:
 
 if args.write_pdbqt is not None:
     if args.write_pdbqt:
-        if args.write_pdbqt.endswith(".pdbqt"):
-            fn_base = args.write_pdbqt.rstrip(".pdbqt")
+        if args.write_pdbqt[0].endswith(".pdbqt"):
+            # may need to suffix _rigid/_flex with flexres
+            fn_base = str(pathlib.Path(args.write_pdbqt[0]).with_suffix(""))
         else:
             fn_base = args.write_pdbqt[0]
     else:
@@ -713,7 +714,7 @@ def warn_flexres_outside_box(chorizo, box_center, box_size):
         if not res.is_movable:
             continue
         for atom in res.molsetup.atoms:
-            if not res.is_flexres_atom[atom.index]:  # TODO: not implemented
+            if not res.is_flexres_atom[atom.index]:
                 continue
             if gridbox.is_point_outside_box(atom.coord, box_center, box_size, spacing=1.0):
                 print(

--- a/test/linked_rdkit_chorizo_creation_test.py
+++ b/test/linked_rdkit_chorizo_creation_test.py
@@ -74,7 +74,10 @@ def test_flexres_pdbqt():
         set_templates,
         blunt_ends=[(":5", 0), (":18", 2)],
     )
+    res11 = chorizo.residues[":11"]
+    assert sum(res11.is_flexres_atom) == 0
     chorizo.flexibilize_sidechain(":11", mk_prep)
+    assert sum(res11.is_flexres_atom) == 9
     rigid, flex_dict = PDBQTWriterLegacy.write_from_linked_rdkit_chorizo(chorizo)
     nr_rigid_atoms = len(rigid.splitlines())
     assert nr_rigid_atoms == 124
@@ -368,7 +371,7 @@ def test_altloc():
             chem_templates,
             mk_prep,
         )
-    assert str(err_msg.value).startswith("Handle AltLocs")
+    assert "altloc" in str(err_msg.value).lower()
 
     chorizo = LinkedRDKitChorizo.from_pdb_string(
         pdb_text,


### PR DESCRIPTION
Populate list to label each atom as movable in a flexible sidechain or not. Some code from writer.py still needs to be removed as it's redundant now.