### PR TITLE
suppress rdkit reaction atom map warning in residue padder

### DIFF
--- a/meeko/__init__.py
+++ b/meeko/__init__.py
@@ -50,6 +50,15 @@ from .openff_xml_parser import load_openff
 from .openff_xml_parser import get_openff_epsilon_sigma
 from .hydrate import Hydrate
 
+import logging
+from rdkit import rdBase
+rdkit_logger = logging.getLogger("rdkit")
+rdkit_logger.handlers[0].setLevel("WARNING")
+rdkit_logger.handlers[0].setFormatter(
+    logging.Formatter('[RDKit] %(levelname)s:%(message)s'),
+)
+rdBase.LogToPythonLogger()
+
 __all__ = ['MoleculePreparation', 'RDKitMoleculeSetup', 'MoleculeSetupEncoder',
            'pdbutils', 'geomutils', 'rdkitutils', 'utils',
            'AtomTyper', 'PDBQTMolecule', 'PDBQTReceptor', 'analysis',


### PR DESCRIPTION
For the reaction run by ResiduePadders, it suppresses the following rdkit warnings:
```
[23:00:47] product atom-mapping number 11 not found in reactants.
[23:00:47] product atom-mapping number 12 not found in reactants.
[23:00:47] product atom-mapping number 11 not found in reactants.
[23:00:47] product atom-mapping number 12 not found in reactants.
[23:00:47] product atom-mapping number 13 not found in reactants.
```
these arise because the product has atom labels that the reactants don't, but those labels are added on purpose. The filter is removed immediately after the reaction. Since the logger is a singleton, it is not guaranteed that the same warning won't be suppressed when multiprocessing from some other reaction that happens to be running, but I think that's OK.