### PR TITLE
minor fix in error messages from mk_prepare_ligand stdout pdbqt

### DIFF
--- a/scripts/mk_prepare_ligand.py
+++ b/scripts/mk_prepare_ligand.py
@@ -644,7 +644,7 @@ if __name__ == "__main__":
         print(output.get_duplicates_info_string())
 
     # Determine if exit code should be non-zero based on processing results
-    if output.num_files_written == 0:
+    if output.num_files_written == 0 and not output.redirect_stdout:
         print("No PDBQT files were written due to errors!")
         sys.exit(3)  # full failure
     elif input_mol_with_failure > 0:


### PR DESCRIPTION
When using -/--, no PDBQT files are written, as expected, but there' was an unwanted error message about zero files being written.