### PR TITLE
use absolute import to import covalent_radius in chemtemgen.py

### DIFF
--- a/meeko/chemtempgen.py
+++ b/meeko/chemtempgen.py
@@ -9,7 +9,7 @@ import re
 import atexit
 import os
 
-from .utils.rdkitutils import covalent_radius
+from meeko.utils.rdkitutils import covalent_radius
 
 from rdkit import Chem
 from rdkit.Chem import rdmolops


### PR DESCRIPTION
There was a small problem when I wanted to `import meeko.chemtempgen` in a Python script. Changing 

```py
from .utils.rdkitutils import covalent_radius
```

To

```py
from meeko.utils.rdkitutils import covalent_radius
```