### PR TITLE
update offatom test to 0-based indexing

### DIFF
--- a/test/rdkitmol_from_docking_test.py
+++ b/test/rdkitmol_from_docking_test.py
@@ -140,8 +140,8 @@ def test_offsite_charges():
         "input_offatom_params": {
             "offsite": [
                 {"smarts": "[#7X3;v3;!+]([*])([*])[*]",
-                 "IDX": [1],
-                 "OFFATOMS": [{"z": [2, 3, 4], "phi": 0, "distance": 0.2, "atype": "LP", "pull_charge_fraction": 1.08}]
+                 "IDX": [0],
+                 "OFFATOMS": [{"z": [1, 2, 3], "phi": 0, "distance": 0.2, "atype": "LP", "pull_charge_fraction": 1.08}]
                  }
             ]
         }


### PR DESCRIPTION
Forgot to update the test. Indices of atoms in SMARTS strings used in typing now start at zero