### PR TITLE
fix link to readthedocs, fix cli help msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![API stability](https://img.shields.io/badge/stable%20API-no-orange)](https://shields.io/)
 [![PyPI version fury.io](https://img.shields.io/badge/version-0.6.0-green.svg)](https://pypi.python.org/pypi/meeko/)
-[![Documentation Status](https://readthedocs.org/projects/meeko/badge/?version=readthedocs)](https://meeko.readthedocs.io/en/readthedocs/?badge=readthedocs)
+[![Documentation Status](https://readthedocs.org/projects/meeko/badge/?version=release)](https://meeko.readthedocs.io/en/release/?badge=release)
 
 Meeko prepares the input for AutoDock and processes its output.
 It is developed alongside AutoDock-GPU and AutoDock-Vina.
@@ -16,7 +16,7 @@ at [Scripps Research](https://www.scripps.edu/).
 
 ## Documentation
 
-The docs are hosted on [meeko.readthedocs.io](meeko.readthedocs.io)
+The docs are hosted on [meeko.readthedocs.io](https://meeko.readthedocs.io/en/release)
 
 
 ## Reporting bugs
@@ -42,7 +42,7 @@ pip install meeko
 
 Meeko exposes a Python API to enable scripting. Here we share very minimal examples
 using the command line scripts just to give context.
-Please visit the [meeko.readthedocs.io](meeko.readthedocs.io) for more information.
+Please visit the [meeko.readthedocs.io](https://meeko.readthedocs.io/en/release) for more information.
 
 Parameterizing a ligand and writing a PDBQT file:
 ```bash

--- a/meeko/cli/mk_prepare_receptor.py
+++ b/meeko/cli/mk_prepare_receptor.py
@@ -184,7 +184,7 @@ def get_args():
         "--flexres",
         action="append",
         default=[],
-        help='specify the flexible residues by the chain ID and residue number, e.g. -f ":42,B:23" is equivalent to -f ":42" -f "B:23" (skip chain ID if it is unspecified)',
+        help='specify the flexible residues by the chain ID and residue number, e.g. -f ":42,B:23" is equivalent to -f ":42" -f "B:23" (leave chain ID empty if omitted in input PDB or mmCIF)',
     )
 
     box_group = parser.add_argument_group("Size and center of grid box")


### PR DESCRIPTION
README links to readthedocs now work

as suggested in https://github.com/ccsb-scripps/AutoDock-Vina/issues/319 help message for flexres option in mk_prepare_receptor.py now does not suggest that chain ID is optional, new message reads:
> leave chain ID empty if omitted in input PDB or mmCIF

old message was:
> skip chain ID if it is unspecified