### PR TITLE
add meeko/data/params/* to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,6 @@ include LICENSE
 include test/*
 include example/*
 include meeko/data/*
+include meeko/data/params/*
 include meeko/tmp/*
 include meeko/utils/*


### PR DESCRIPTION
it appears that basic functionality isn't working with meeko installed from pip or conda, because the JSON files with the default atom types isn't being distributed