### PR TITLE
type aniline-like N in triazene as N, not NA

### DIFF
--- a/meeko/data/params/ad4_types.json
+++ b/meeko/data/params/ad4_types.json
@@ -20,6 +20,7 @@
     {"smarts": "[#53]",             "atype": "I"},
     {"smarts": "[#7X3v3][a]",       "atype": "N",  "comment": "pyrrole, aniline"},
     {"smarts": "[#7X3v3][#6X3v4]",  "atype": "N",  "comment": "amide"},
+    {"smarts": "[#7X3v3][NX2]=[*]", "atype": "N",  "comment": "triazene"},
     {"smarts": "[#7+1]",            "atype": "N",  "comment": "ammonium, pyridinium"},
     {"smarts": "[SX2]",             "atype": "SA", "comment": "sulfur acceptor"}
     ]


### PR DESCRIPTION
This fixes #240

Nitrogens with three neighbors with a single bond to a second nitrogen (N_2) that has a double bound to a third atom, for example in triazene `"NN=N"` have a torsion profile with a strong planar preference. Then I assume these nitrogens are more like amide or aniline, than amine, and this PR now types them as N instead of NA. 