### PR TITLE
uniformize os.linesep as eol (no pathlib.os in Python 3.13)

### DIFF
--- a/meeko/analysis/fingerprint_interactions.py
+++ b/meeko/analysis/fingerprint_interactions.py
@@ -4,8 +4,6 @@
 # Meeko
 #
 
-import os
-
 import numpy as np
 try:
     import pandas as pd

--- a/meeko/analysis/interactions.py
+++ b/meeko/analysis/interactions.py
@@ -4,7 +4,6 @@
 # Meeko - Interactions
 #
 
-import os
 from abc import ABC, abstractmethod
 
 import numpy as np

--- a/meeko/bondtyper.py
+++ b/meeko/bondtyper.py
@@ -4,11 +4,6 @@
 # Meeko bond typer
 #
 
-import os
-import sys
-from collections import defaultdict
-from operator import itemgetter
-
 
 class BondTyperLegacy:
 

--- a/meeko/cli/mk_export.py
+++ b/meeko/cli/mk_export.py
@@ -7,6 +7,7 @@ import argparse
 import gzip
 import pathlib
 import sys
+from os import linesep as eol
 import warnings
 import copy
 import numpy as np
@@ -143,10 +144,10 @@ def main():
                 iter_pose._positions = np.array([pdbqt_mol._positions[pose_id]])
                 iter_pose._pose_data['n_poses'] = 1  # Update the number of poses to reflect the reduction
                 iter_pose._current_pose = 0  # Reset to the first (and only) pose
-                pdb_string += "MODEL " + f"{model_nr:8}" + pathlib.os.linesep
+                pdb_string += "MODEL " + f"{model_nr:8}" + eol
                 pol_copy = copy.deepcopy(polymer)
                 pdb_string += export_pdb_updated_flexres(pol_copy, iter_pose)
-                pdb_string += "ENDMDL" + pathlib.os.linesep
+                pdb_string += "ENDMDL" + eol
             if write_pdb is None:
                 fn = pathlib.Path(filename).with_suffix("").name + f"{suffix}.pdb"
             else:

--- a/meeko/cli/mk_prepare_ligand.py
+++ b/meeko/cli/mk_prepare_ligand.py
@@ -7,6 +7,7 @@ import argparse
 from datetime import datetime
 import io
 import os
+from os import linesep as eol
 import sys
 import json
 import tarfile
@@ -333,7 +334,7 @@ def cmd_lineparser():
         sys.exit(2)
     is_covalent = num_required_covalent_args == 3
     if is_covalent and not _has_prody:
-        msg = "Covalent docking requires Prody which is not installed." + os.linesep
+        msg = "Covalent docking requires Prody which is not installed." + eol
         msg += "Installable from PyPI (pip install prody) or conda-forge (micromamba install prody)"
         print(_prody_import_error, file=sys.stderr)
         print(msg)

--- a/meeko/cli/mk_prepare_receptor.py
+++ b/meeko/cli/mk_prepare_receptor.py
@@ -3,7 +3,7 @@
 import argparse
 import json
 import math
-from os import linesep as os_linesep
+from os import linesep as eol
 import pathlib
 import sys
 
@@ -265,19 +265,19 @@ def get_args():
     if args.read_pdb is None and args.read_with_prody is None:
         parser.print_help()
         msg = "Need input filename: use either -i/--read_with_prody or --read_pdb"
-        print(os_linesep + msg)
+        print(eol + msg)
         sys.exit(2)
 
     if args.read_pdb is not None and args.read_with_prody is not None:
         msg = "Can't use both -i/--read_with_prody and --read_pdb"
-        print(os_linesep + msg, file=sys.stderr)
+        print(eol + msg, file=sys.stderr)
         sys.exit(2)
 
     if args.write_gpf is not None and args.write_pdbqt is None:
         # there's a few of places that assume this condition has been checked
         msg = "--write_gpf requires --write_pdbqt because autogrid expects"
         msg += " the GPF file to point to the PDBQT file." 
-        print(os_linesep + msg)
+        print(eol + msg)
         sys.exit(2)
 
     skip_gpf = args.write_gpf is None and args.write_vina_box is None
@@ -397,7 +397,7 @@ def main():
             print(
                 "Command line error: repeated resname %s passed to --reactive_resname"
                 % resname
-                + os_linesep,
+                + eol,
                 file=sys.stderr,
             )
             sys.exit(2)
@@ -414,7 +414,7 @@ def main():
                 print(
                     "Command line error: repeated resid %s passed to --reactive_name_specific"
                     % res_id
-                    + os_linesep,
+                    + eol,
                     file=sys.stderr,
                 )
                 sys.exit(2)
@@ -439,7 +439,7 @@ def main():
     # Evaluate compatibility with other options
     if len(reactive_flexres) != 1 and args.box_center_off_reactive_res:
         msg = (
-            "--box_center_off_reactive_res can be used only with one reactive" + os_linesep
+            "--box_center_off_reactive_res can be used only with one reactive" + eol
         )
         msg += "residue, but %d reactive residues are set" % len(reactive_flexres_name)
         print("Command line error:" + msg, file=sys.stderr)
@@ -539,7 +539,7 @@ def main():
                 reactive_flexres_name[res_id] = reactive_atom[input_resname]
             else:
                 print("no default reactive name for %s, " % input_resname)
-                print("use --reactive_name or --reactive_name_specific" + os_linesep)
+                print("use --reactive_name or --reactive_name_specific" + eol)
                 sys.exit(2)
     
     # Print nonreactive and reactive flexible residues specs
@@ -680,12 +680,12 @@ def main():
                     continue
                 if gridbox.is_point_outside_box(atom.coord, box_center, box_size, spacing=1.0):
                     print(
-                        "WARNING: Flexible residue outside box." + os_linesep,
+                        "WARNING: Flexible residue outside box." + eol,
                         file=sys.stderr,
                     )
                     print(
                         "WARNING: Strongly recommended to use a box that encompasses flexible residues."
-                        + os_linesep,
+                        + eol,
                         file=sys.stderr,
                     )
                     break  # only need to warn once
@@ -850,7 +850,7 @@ def main():
                 any_lig_reac_types.append(reactive_typer.get_reactive_atype(t, order))
     
         rec_reac_types = []
-        for line in all_flex_pdbqt.split(os_linesep):
+        for line in all_flex_pdbqt.split(eol):
             if line.startswith("ATOM") or line.startswith("HETATM"):
                 atype = line[77:].strip()
                 basetype, _ = reactive_typer.get_basetype_and_order(atype)
@@ -869,7 +869,7 @@ def main():
         if len(collisions) > 0:
             collision_str = ""
             for t1, t2 in collisions:
-                collision_str += "%3s %3s" % (t1, t2) + os_linesep
+                collision_str += "%3s %3s" % (t1, t2) + eol
             collision_fn = str(outpath.with_suffix(".atype_collisions"))
             written_files_log["filename"].append(collision_fn)
             written_files_log["description"].append(
@@ -887,19 +887,19 @@ def main():
         all_types = []
         for basetype, reactypes in derivtypes.items():
             all_types.append(basetype)
-            map_block += "map %s.%s.map" % (map_prefix, basetype) + os_linesep
+            map_block += "map %s.%s.map" % (map_prefix, basetype) + eol
             for reactype in reactypes:
                 all_types.append(reactype)
-                map_block += "map %s.%s.map" % (map_prefix, basetype) + os_linesep
-        config = "ligand_types " + " ".join(all_types) + os_linesep
-        config += "fld %s.maps.fld" % map_prefix + os_linesep
+                map_block += "map %s.%s.map" % (map_prefix, basetype) + eol
+        config = "ligand_types " + " ".join(all_types) + eol
+        config += "fld %s.maps.fld" % map_prefix + eol
         config += map_block
     
         # in modpairs (dict): types are keys, parameters are values
         # now we will write a configuration file with nbp keywords
         # that AD-GPU reads using the --import_dpf flag
         # nbp stands for "non-bonded potential" or "non-bonded pairwise"
-        line = "intnbp_r_eps %8.6f %8.6f %3d %3d %4s %4s" + os_linesep
+        line = "intnbp_r_eps %8.6f %8.6f %3d %3d %4s %4s" + eol
         nbp_count = 0
         for (t1, t2), param in modpairs.items():
             config += line % (param["r_eq"], param["eps"], param["n"], param["m"], t1, t2)

--- a/meeko/gridbox.py
+++ b/meeko/gridbox.py
@@ -1,4 +1,4 @@
-from os import linesep as os_linesep
+from os import linesep as eol
 import pathlib
 import numpy as np
 
@@ -82,7 +82,7 @@ def box_to_pdb_string(box_center, npts, spacing=0.375):
     res = "BOX"
     chain = "X"
     pdb_out = ""
-    line = "ATOM  %5d %4s %3s %1s%4d    %8.3f%8.3f%8.3f  1.00 10.00          %1s" + os_linesep
+    line = "ATOM  %5d %4s %3s %1s%4d    %8.3f%8.3f%8.3f  1.00 10.00          %1s" + eol
     for idx in range(len(corners)):
         x = corners[idx][0]
         y = corners[idx][1]
@@ -93,18 +93,18 @@ def box_to_pdb_string(box_center, npts, spacing=0.375):
     # center
     pdb_out += line % (count+1, "Xe", res, chain, idx+1, center_x, center_y, center_z, "Xe")
 
-    pdb_out += "CONECT    1    2" + os_linesep
-    pdb_out += "CONECT    1    4" + os_linesep
-    pdb_out += "CONECT    1    5" + os_linesep
-    pdb_out += "CONECT    2    3" + os_linesep
-    pdb_out += "CONECT    2    6" + os_linesep
-    pdb_out += "CONECT    3    4" + os_linesep
-    pdb_out += "CONECT    3    7" + os_linesep
-    pdb_out += "CONECT    4    8" + os_linesep
-    pdb_out += "CONECT    5    6" + os_linesep
-    pdb_out += "CONECT    5    8" + os_linesep
-    pdb_out += "CONECT    6    7" + os_linesep
-    pdb_out += "CONECT    7    8" + os_linesep
+    pdb_out += "CONECT    1    2" + eol
+    pdb_out += "CONECT    1    4" + eol
+    pdb_out += "CONECT    1    5" + eol
+    pdb_out += "CONECT    2    3" + eol
+    pdb_out += "CONECT    2    6" + eol
+    pdb_out += "CONECT    3    4" + eol
+    pdb_out += "CONECT    3    7" + eol
+    pdb_out += "CONECT    4    8" + eol
+    pdb_out += "CONECT    5    6" + eol
+    pdb_out += "CONECT    5    8" + eol
+    pdb_out += "CONECT    6    7" + eol
+    pdb_out += "CONECT    7    8" + eol
     return pdb_out
 
 def is_point_outside_box(point, center, npts, spacing=0.375):
@@ -156,5 +156,5 @@ def box_to_vina_string(gridcenter, gridsizes):
     sizes_str = "\n".join([f"size_{d} = {gridsizes[i]:.3f}" for i, d in enumerate(dims)])
     return centers_str + "\n" + sizes_str
 
-boron_silicon_atompar  = "atom_par Si     4.10  0.200  35.8235  -0.00143  0.0  0.0  0  -1  -1  6" + os_linesep
-boron_silicon_atompar += "atom_par B      3.84  0.155  29.6478  -0.00152  0.0  0.0  0  -1  -1  0" + os_linesep
+boron_silicon_atompar  = "atom_par Si     4.10  0.200  35.8235  -0.00143  0.0  0.0  0  -1  -1  6" + eol
+boron_silicon_atompar += "atom_par B      3.84  0.155  29.6478  -0.00152  0.0  0.0  0  -1  -1  0" + eol

--- a/meeko/polymer.py
+++ b/meeko/polymer.py
@@ -3,7 +3,7 @@ import json
 import logging
 import traceback
 from importlib.resources import files
-from os import linesep as os_linesep
+from os import linesep as eol
 from sys import exc_info
 from typing import Union
 from typing import Optional
@@ -494,19 +494,19 @@ class PolymerCreationError(RuntimeError):
             self.traceback = None
 
     def __str__(self):
-        msg = "" + os_linesep
-        msg += "Error: Creation of data structure for receptor failed." + os_linesep
-        msg += "" + os_linesep
-        msg += "Details:" + os_linesep
-        msg += self.error + os_linesep
+        msg = "" + eol
+        msg += "Error: Creation of data structure for receptor failed." + eol
+        msg += "" + eol
+        msg += "Details:" + eol
+        msg += self.error + eol
 
         if self.traceback:
-            msg += self.traceback + os_linesep
+            msg += self.traceback + eol
 
         if self.recommendations: 
-            msg += "Recommendations:" + os_linesep
-            msg += self.recommendations + os_linesep
-            msg += "" + os_linesep
+            msg += "Recommendations:" + eol
+            msg += self.recommendations + eol
+            msg += "" + eol
         
         return msg
 
@@ -523,7 +523,7 @@ def handle_parsing_situations(
     if unparsed_res:
         msg = f"- Parsing failed for: {unparsed_res}."
         if not allow_bad_res:
-            err += msg + os_linesep
+            err += msg + eol
         else: 
             msg += " Ignored due to allow_bad_res."
             logger.warning(msg)
@@ -531,30 +531,30 @@ def handle_parsing_situations(
     if unmatched_res:
         msg = f"- Template matching failed for: {list(unmatched_res)}"
         if not allow_bad_res:
-            err += msg + os_linesep
+            err += msg + eol
         else:
             msg += " Ignored due to allow_bad_res."
             logger.warning(msg)
 
     if err:
-        err += "These residues can be ignored with option allow_bad_res." + os_linesep
+        err += "These residues can be ignored with option allow_bad_res." + eol
 
     if res_needed_altloc: 
-        msg = f"- Residues with alternate location: {res_needed_altloc}" + os_linesep
-        msg += "Either specify an altloc for each with option wanted_altloc" + os_linesep
+        msg = f"- Residues with alternate location: {res_needed_altloc}" + eol
+        msg += "Either specify an altloc for each with option wanted_altloc" + eol
         msg += "or a general default altloc with option default_altloc."
         err += msg
 
     if res_missed_altloc:
-        msg = f"- Requested altlocs not found for: {res_missed_altloc}." + os_linesep
+        msg = f"- Requested altlocs not found for: {res_missed_altloc}." + eol
         err += msg
 
     if err:
-        recs = "1. (for batch processing) Use -a/--allow_bad_res to automatically remove residues" + os_linesep
-        recs += "that do not match templates, and --default_altloc to set" + os_linesep
-        recs += "a default altloc variant. Use these at your own risk." + os_linesep
-        recs += "" + os_linesep
-        recs += "2. (processing individual structure) Inspecting and fixing the input structure is recommended." + os_linesep
+        recs = "1. (for batch processing) Use -a/--allow_bad_res to automatically remove residues" + eol
+        recs += "that do not match templates, and --default_altloc to set" + eol
+        recs += "a default altloc variant. Use these at your own risk." + eol
+        recs += "" + eol
+        recs += "2. (processing individual structure) Inspecting and fixing the input structure is recommended." + eol
         recs += "Use --wanted_altloc to set variants for specific residues."
         raise PolymerCreationError(err, recs)
     return
@@ -776,9 +776,9 @@ class Polymer:
         if type(raw_input_mols) != dict:
             msg = f"expected raw_input_mols to be dict, got {type(raw_input_mols)}"
             if type(raw_input_mols) == str:
-                msg += os_linesep
+                msg += eol
                 msg += (
-                    "consider Polymer.from_pdb_string(pdbstr)" + os_linesep
+                    "consider Polymer.from_pdb_string(pdbstr)" + eol
                 )
             raise ValueError(msg)
         self.residue_chem_templates = residue_chem_templates
@@ -812,25 +812,25 @@ class Polymer:
         if unknown_res_from_input:
             unknown_valid_res_from_input = {k: v for k, v in unknown_res_from_input.items() if v != "UNL"}
             if unknown_valid_res_from_input: 
-                err += f"Input residues {unknown_valid_res_from_input} not in residue_templates" + os_linesep
+                err += f"Input residues {unknown_valid_res_from_input} not in residue_templates" + eol
             UNL_from_input = {k: v for k, v in unknown_res_from_input.items() if v == "UNL"}
             if UNL_from_input: 
-                err += f"Input residues {UNL_from_input} do not have a concrete definition" + os_linesep
+                err += f"Input residues {UNL_from_input} do not have a concrete definition" + eol
         
         unknown_res_from_assign = {}
         if set_template:
             unknown_res_from_assign = {res_id: resn for res_id, resn in set_template.items() if resn not in supported_resnames}
             unknown_valid_res_from_assign = {k: v for k, v in unknown_res_from_assign.items() if v != "UNL"}
             if unknown_valid_res_from_assign: 
-                err += f"Input residues {unknown_valid_res_from_assign} not in residue_templates" + os_linesep
+                err += f"Input residues {unknown_valid_res_from_assign} not in residue_templates" + eol
             UNL_from_assign = {k: v for k, v in unknown_res_from_assign.items() if v == "UNL"}
             if UNL_from_assign: 
-                err += f"Input residues {UNL_from_assign} do not have a concrete definition" + os_linesep
+                err += f"Input residues {UNL_from_assign} do not have a concrete definition" + eol
         
         if err:
             if "UNL" in err: 
-                err += "Resdiues that are named UNL can't be parameterized. " + os_linesep
-                rec = "1. (to parameterize the residues) Use --set_template to specify valid residue names, " + os_linesep
+                err += "Resdiues that are named UNL can't be parameterized. " + eol
+                rec = "1. (to parameterize the residues) Use --set_template to specify valid residue names, " + eol
                 rec += "2. (to skip the residues) Use --delete_residues to ignore them. Residues will be deleted from the prepared receptor. "
                 raise PolymerCreationError(err, rec)
 
@@ -883,9 +883,9 @@ class Polymer:
                     raise PolymerCreationError(str(e))
                             
                 if failed_build: 
-                    raise PolymerCreationError(f"Template generation failed for unknown residues: {failed_build}, which appear to be linking fragments. " + os_linesep
+                    raise PolymerCreationError(f"Template generation failed for unknown residues: {failed_build}, which appear to be linking fragments. " + eol
                                             + "Generation of chemical templates with modified backbones, which involves guessing of linker positions and types, are not currently supported. ", 
-                                            "1. (to parameterize the residues) Use --add_templates to pass the additional templates with valid linker_labels, " + os_linesep
+                                            "1. (to parameterize the residues) Use --add_templates to pass the additional templates with valid linker_labels, " + eol
                                             + "2. (to skip the residues) Use --delete_residues to ignore them. Residues will be deleted from the prepared receptor. ")
 
         self.monomers, self.log = self._get_monomers(
@@ -1373,10 +1373,10 @@ class Polymer:
                 template_key = None
                 template = None
                 mapping = None
-                m = f"No template matched for {residue_key=}" + os_linesep
+                m = f"No template matched for {residue_key=}" + eol
                 m += f"tried {len(candidate_templates)} templates for {residue_key=}"
                 m += f"{excess_H_ok=}"
-                m += os_linesep
+                m += eol
                 for i in range(len(all_stats["H_excess"])):
                     heavy_miss = all_stats["heavy_missing"][i]
                     heavy_excess = all_stats["heavy_excess"][i]
@@ -1386,7 +1386,7 @@ class Polymer:
                     tkey = candidate_template_keys[i]
                     m += (
                         f"{tkey:10} {heavy_miss=} {heavy_excess=} {H_excess=} {bond_miss=} {bond_excess=}"
-                        + os_linesep
+                        + eol
                     )
                 logger.warning(m)
             elif len(passed) == 1 or not raw_mol_has_H:
@@ -1546,7 +1546,7 @@ class Polymer:
             if count != 2:
                 err_msg += (
                     f"expected two paddings for {key} {bonds[key]}, padded {count}"
-                    + os_linesep
+                    + eol
                 )
         if len(err_msg):
             raise RuntimeError(err_msg)
@@ -1684,7 +1684,7 @@ class Polymer:
         # verify that each identifier (e.g. "A:17" has a single resname
         violations = {k: v for k, v in reskey_to_resname.items() if len(v) != 1}
         if len(violations):
-            msg = "each residue key must have exactly 1 resname" + os_linesep
+            msg = "each residue key must have exactly 1 resname" + eol
             msg += f"but got {violations=}"
             raise ValueError(msg)
 
@@ -1785,7 +1785,7 @@ class Polymer:
         pdbout = ""
         atom_count = 0
         pdb_line = "{:6s}{:5d} {:^4s} {:3s} {:1s}{:4d}{:1s}   {:8.3f}{:8.3f}{:8.3f}                       {:2s} "
-        pdb_line += pathlib.os.linesep
+        pdb_line += eol
         for res_id in self.get_valid_monomers():
             rdkit_mol = self.monomers[res_id].rdkit_mol
             if res_id in new_positions:

--- a/meeko/preparation.py
+++ b/meeko/preparation.py
@@ -6,7 +6,7 @@
 
 from inspect import signature
 import json
-import os
+from os import linesep as eol
 import pathlib
 import warnings
 
@@ -219,10 +219,10 @@ class MoleculePreparation:
         bad_keys = [k for k in config if k not in expected_keys]
         if len(bad_keys) > 0:
             err_msg = (
-                "unexpected keys in MoleculePreparation.from_config():" + os.linesep
+                "unexpected keys in MoleculePreparation.from_config():" + eol
             )
             for key in bad_keys:
-                err_msg += "  - %s" % key + os.linesep
+                err_msg += "  - %s" % key + eol
             raise ValueError(err_msg)
         p = cls(**config)
         return p
@@ -345,12 +345,12 @@ class MoleculePreparation:
             else:
                 msg = (
                     "names passed to 'load_atom_params' need to suffixed with .json"
-                    + os.linesep
+                    + eol
                 )
                 msg += (
                     "or be the unsuffixed basename of a JSON file in %s."
                     % str(params_dir)
-                    + os.linesep
+                    + eol
                 )
                 msg += "name was %s" % name
                 raise ValueError(msg)
@@ -626,7 +626,7 @@ class MoleculePreparation:
         warnings.warn(msg, DeprecationWarning)
         pdbqt_string, is_ok, err_msg = PDBQTWriterLegacy.write_string(self.setup)
         if not is_ok:
-            msg = "Cannot generate PDBQT, error from PDBQTWriterLegacy:" + os.linesep
+            msg = "Cannot generate PDBQT, error from PDBQTWriterLegacy:" + eol
             msg += err_msg
             raise RuntimeError(msg)
         return pdbqt_string

--- a/meeko/rdkit_mol_create.py
+++ b/meeko/rdkit_mol_create.py
@@ -10,7 +10,6 @@ from rdkit.Geometry import Point3D
 from rdkit.Chem import AllChem
 from io import StringIO
 import json
-import os
 
 
 def clean_extend(existing_dict, new_row):

--- a/meeko/reactive.py
+++ b/meeko/reactive.py
@@ -5,7 +5,6 @@
 #
 
 from math import sqrt
-from os import linesep as os_linesep
 
 class ReactiveAtomTyper:
 

--- a/meeko/receptor_pdbqt.py
+++ b/meeko/receptor_pdbqt.py
@@ -6,7 +6,7 @@
 
 from collections import defaultdict
 import json
-from os import linesep as os_linesep
+from os import linesep as eol
 
 import numpy as np
 from scipy import spatial
@@ -42,7 +42,7 @@ def _read_receptor_pdbqt_string(pdbqt_string, skip_typing=False):
     pseudo_atom_types = ['TZ']
 
     idx = 0
-    for line in pdbqt_string.split(os_linesep):
+    for line in pdbqt_string.split(eol):
         if line.startswith('ATOM') or line.startswith("HETATM"):
             serial = int(line[6:11].strip())
             name = line[12:16].strip()

--- a/meeko/writer.py
+++ b/meeko/writer.py
@@ -7,7 +7,7 @@
 import sys
 import json
 import math
-import pathlib
+from os import linesep as eol
 
 import numpy as np
 from rdkit import Chem
@@ -15,8 +15,6 @@ from .utils import pdbutils
 from .utils.rdkitutils import mini_periodic_table
 
 from .molsetup import Bond
-
-linesep = pathlib.os.linesep
 
 
 def oids_json_from_setup(molsetup, name="LigandFromMeeko"):
@@ -573,7 +571,7 @@ class PDBQTWriterLegacy:
                         atom_type,
                         icode,
                     )
-                    + linesep
+                    + eol
                 )
         return rigid_pdbqt_string, flex_pdbqt_dict
 
@@ -684,7 +682,7 @@ class PDBQTWriterLegacy:
         # torsdof is always going to be the one of the rigid, non-macrocyclic one
         data["pdbqt_buffer"].append("TORSDOF %d" % active_tors)
 
-        pdbqt_string = linesep.join(data["pdbqt_buffer"]) + linesep
+        pdbqt_string = eol.join(data["pdbqt_buffer"]) + eol
         return pdbqt_string, success, error_msg
 
     @classmethod
@@ -738,10 +736,10 @@ class PDBQTWriterLegacy:
          - remove TORSDOF
         this is for covalent docking (tethered)
         """
-        new_string = "BEGIN_RES %s %s %s" % (res, chain, num) + linesep
+        new_string = "BEGIN_RES %s %s %s" % (res, chain, num) + eol
         atom_number = 0
         offset = atom_count
-        for line in pdbqt_string.split(linesep):
+        for line in pdbqt_string.split(eol):
             if line == "":
                 continue
             if line.startswith("TORSDOF"):
@@ -758,18 +756,18 @@ class PDBQTWriterLegacy:
                     n = "%5d" % atom_count
                     n = n[:5]
                     line = line[:6] + n + line[11:]
-                new_string += line + linesep
+                new_string += line + eol
                 continue
             elif offset is not None and (
                 line.startswith("BRANCH") or line.startswith("ENDBRANCH")
             ):
                 keyword, i, j = line.split()
                 new_string += (
-                    f"{keyword} {int(i)+offset:3d} {int(j)+offset:3d}" + linesep
+                    f"{keyword} {int(i)+offset:3d} {int(j)+offset:3d}" + eol
                 )
                 continue
-            new_string += line + linesep
-        new_string += "END_RES %s %s %s" % (res, chain, num) + linesep
+            new_string += line + eol
+        new_string += "END_RES %s %s %s" % (res, chain, num) + eol
         if atom_count is None:
             return new_string  # just keeping backwards compatibility
         else:

--- a/test/polymer_creation_test.py
+++ b/test/polymer_creation_test.py
@@ -1,7 +1,6 @@
 import json
 import pathlib
 import pytest
-import os
 
 from meeko import Polymer
 from meeko import PDBQTWriterLegacy
@@ -429,9 +428,6 @@ def test_weird_zero_coord():
     with open(has_lys) as f:
         pdbstr = f.read()
     polymer = Polymer.from_pdb_string(pdbstr, chem_templates, mk_prep)
-    #pdbqt_strings = PDBQTWriterLegacy.write_string_from_polymer(polymer)
-    with open("BANANACUUBER.json", "w") as f:
-        f.write(polymer.to_json())
     for _, res in polymer.monomers.items():
         positions = res.rdkit_mol.GetConformer().GetPositions()
         for atom in res.molsetup.atoms:


### PR DESCRIPTION
thanks @atillack for pointing out that `pathlib.os` was dropped in Python 3.13

this PR uniformizes the use of `os.linesep` as `eol`

several unused `import os` were removed