### PR TITLE
Use utility functions in jsonutils to fix #151

### DIFF
--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -1377,7 +1377,7 @@ class MoleculeSetup:
             obj["ring_closure_info"]["bonds_removed"],
             obj["ring_closure_info"]["pseudos_by_atom"],
         )
-        molsetup.rotamers = obj["rotamers"]
+        molsetup.rotamers = [{string_to_tuple(k, element_type=int): v for k,v in rotamer.items()} for rotamer in obj["rotamers"]]
         molsetup.atom_params = obj["atom_params"]
         molsetup.restraints = [Restraint.from_json(x) for x in obj["restraints"]]
         molsetup.flexibility_model = obj["flexibility_model"]
@@ -2147,8 +2147,8 @@ class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolkit):
         ]
         # TODO: Dihedral decoding may need another look
         rdkit_molsetup.dihedral_interactions = obj["dihedral_interactions"]
-        rdkit_molsetup.dihedral_partaking_atoms = obj["dihedral_partaking_atoms"]
-        rdkit_molsetup.dihedral_labels = obj["dihedral_labels"]
+        rdkit_molsetup.dihedral_partaking_atoms = {string_to_tuple(k, element_type=int): string_to_tuple(v, element_type=int) for k,v in obj["dihedral_partaking_atoms"].items()}
+        rdkit_molsetup.dihedral_labels = {string_to_tuple(k, element_type=int): v for k,v in obj["dihedral_labels"].items()}
         rdkit_molsetup.atom_to_ring_id = {
             int(k): [string_to_tuple(t) for t in v]
             for k, v in obj["atom_to_ring_id"].items()
@@ -2332,7 +2332,7 @@ class MoleculeSetupEncoder(json.JSONEncoder):
                     for k, v in obj.rings.items()
                 },
                 "ring_closure_info": obj.ring_closure_info.__dict__,
-                "rotamers": obj.rotamers,
+                "rotamers": [{tuple_to_string(k): v for k, v in rotamer.items()} for rotamer in obj.rotamers],
                 "atom_params": obj.atom_params,
                 "restraints": [
                     self.restraint_encoder.default(x) for x in obj.restraints
@@ -2358,8 +2358,8 @@ class MoleculeSetupEncoder(json.JSONEncoder):
             output_dict["mol"] = rdMolInterchange.MolToJSON(obj.mol)
             output_dict["modified_atom_positions"] = obj.modified_atom_positions
             output_dict["dihedral_interactions"] = obj.dihedral_interactions
-            output_dict["dihedral_partaking_atoms"] = obj.dihedral_partaking_atoms
-            output_dict["dihedral_labels"] = obj.dihedral_labels
+            output_dict["dihedral_partaking_atoms"] = {tuple_to_string(k): tuple_to_string(v) for k,v in obj.dihedral_partaking_atoms.items()}
+            output_dict["dihedral_labels"] = {tuple_to_string(k): v for k,v in obj.dihedral_labels.items()}
             output_dict["atom_to_ring_id"] = obj.atom_to_ring_id
             output_dict["ring_corners"] = obj.ring_corners
             output_dict["rmsd_symmetry_indices"] = obj.rmsd_symmetry_indices

--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -2147,7 +2147,7 @@ class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolkit):
         ]
         # TODO: Dihedral decoding may need another look
         rdkit_molsetup.dihedral_interactions = obj["dihedral_interactions"]
-        rdkit_molsetup.dihedral_partaking_atoms = {string_to_tuple(k, element_type=int): string_to_tuple(v, element_type=int) for k,v in obj["dihedral_partaking_atoms"].items()}
+        rdkit_molsetup.dihedral_partaking_atoms = {string_to_tuple(k, element_type=int): v for k,v in obj["dihedral_partaking_atoms"].items()}
         rdkit_molsetup.dihedral_labels = {string_to_tuple(k, element_type=int): v for k,v in obj["dihedral_labels"].items()}
         rdkit_molsetup.atom_to_ring_id = {
             int(k): [string_to_tuple(t) for t in v]
@@ -2358,7 +2358,7 @@ class MoleculeSetupEncoder(json.JSONEncoder):
             output_dict["mol"] = rdMolInterchange.MolToJSON(obj.mol)
             output_dict["modified_atom_positions"] = obj.modified_atom_positions
             output_dict["dihedral_interactions"] = obj.dihedral_interactions
-            output_dict["dihedral_partaking_atoms"] = {tuple_to_string(k): tuple_to_string(v) for k,v in obj.dihedral_partaking_atoms.items()}
+            output_dict["dihedral_partaking_atoms"] = {tuple_to_string(k): v for k,v in obj.dihedral_partaking_atoms.items()}
             output_dict["dihedral_labels"] = {tuple_to_string(k): v for k,v in obj.dihedral_labels.items()}
             output_dict["atom_to_ring_id"] = obj.atom_to_ring_id
             output_dict["ring_corners"] = obj.ring_corners

--- a/test/json_serialization_test.py
+++ b/test/json_serialization_test.py
@@ -401,7 +401,6 @@ def check_molsetup_equality(decoded_obj: MoleculeSetup, starting_obj: MoleculeSe
     for idx, component_dict in enumerate(starting_obj.rotamers):
         decoded_dict = decoded_obj.rotamers[idx]
         for key in component_dict:
-            print(key, decoded_dict)
             assert key in decoded_dict
             assert decoded_dict[key] == component_dict[key]
     for key in starting_obj.atom_params:

--- a/test/json_serialization_test.py
+++ b/test/json_serialization_test.py
@@ -31,6 +31,12 @@ from rdkit.Chem import rdChemReactions
 
 from meeko.utils.pdbutils import PDBAtomInfo
 
+try:
+    import openforcefields
+    _got_openff = True
+except ImportError as err:
+    _got_openff = False
+
 # from ..meeko.utils.pdbutils import PDBAtomInfo
 
 pkgdir = pathlib.Path(meeko.__file__).parents[1]
@@ -413,6 +419,11 @@ def check_molsetup_equality(decoded_obj: MoleculeSetup, starting_obj: MoleculeSe
             decoded_obj.restraints[idx], starting_obj.restraints[idx]
         )
 
+    # dihedrals
+    assert decoded_obj.dihedral_partaking_atoms == starting_obj.dihedral_partaking_atoms
+    assert decoded_obj.dihedral_interactions == starting_obj.dihedral_interactions
+    assert decoded_obj.dihedral_labels == starting_obj.dihedral_labels
+
     # Checking flexibility model
     for key in starting_obj.flexibility_model:
         assert key in decoded_obj.flexibility_model
@@ -763,5 +774,18 @@ def check_polymer_equality(
     assert decoded_obj.log == starting_obj.log
     return
 
+@pytest.mark.skipif(not _got_openff, reason="requires openff-forcefields")
+def test_dihedral_equality():
+    mk_prep = MoleculePreparation(
+        merge_these_atom_types=(),
+        dihedral_model="openff",
+    )
+    fn = str(pkgdir/"test"/"flexibility_data"/"non_sequential_atom_ordering_01.mol")
+    mol = Chem.MolFromMolFile(fn, removeHs=False)
+    starting_molsetup = mk_prep(mol)[0]
+    json_str = json.dumps(starting_molsetup, cls=MoleculeSetupEncoder)
+    decoded_molsetup = json.loads(json_str, object_hook=RDKitMoleculeSetup.from_json)
+    check_molsetup_equality(starting_molsetup, decoded_molsetup)
+    return
 
 # endregion

--- a/test/json_serialization_test.py
+++ b/test/json_serialization_test.py
@@ -401,6 +401,7 @@ def check_molsetup_equality(decoded_obj: MoleculeSetup, starting_obj: MoleculeSe
     for idx, component_dict in enumerate(starting_obj.rotamers):
         decoded_dict = decoded_obj.rotamers[idx]
         for key in component_dict:
+            print(key, decoded_dict)
             assert key in decoded_dict
             assert decoded_dict[key] == component_dict[key]
     for key in starting_obj.atom_params:


### PR DESCRIPTION
This is for #151. Used existing utility functions in [jsonutils](https://github.com/forlilab/Meeko/blob/release/meeko/utils/jsonutils.py), tuple_to_string and string_to_tuple to enable encoding and decoding of rotamers data of `rotamers` data for `MoleculeSetup` and `dihedral_partaking_atoms` and `dihedral_labels` for `RDKitMoleculeSetup`. 

@diogomart Could you please review the fixes and let me know if they work as expected? Additionally, I would like to become more familiar with parameter passing, if we might want to store Amber (and other) force field parameters in the future. This is not urgent, please feel free to advise at your convenience 