### PR TITLE
Read Partial Charges from mol2 and SDF

### DIFF
--- a/meeko/cli/mk_prepare_ligand.py
+++ b/meeko/cli/mk_prepare_ligand.py
@@ -79,6 +79,11 @@ def cmd_lineparser():
         help="set molecule name from RDKit/SDF property",
     )
     io_group.add_argument(
+        "--charge_from_prop",
+        nargs="*",
+        help="set atom partial charges from the input file. The default is PartialCharge for SDF and _TriposPartialCharge for MOL2 unless overriden by a user defined property name. ",
+    )
+    io_group.add_argument(
         "-o",
         "--out",
         dest="output_pdbqt_filename",
@@ -214,7 +219,7 @@ def cmd_lineparser():
     )
     config_group.add_argument(
         "--charge_model",
-        choices=("gasteiger", "espaloma", "zero"),
+        choices=("gasteiger", "espaloma", "zero", "read"),
         help="default is 'gasteiger', 'zero' sets all zeros",
         default="gasteiger",
     )
@@ -551,6 +556,19 @@ def main():
     nr_failures = 0
     is_after_first = False
     preparator = MoleculePreparation.from_config(config)
+
+    if args.charge_from_prop is not None: 
+        if args.charge_model != "read": 
+            print('--charge_from_prop must be used with --charge_model "read"')
+            sys.exit(1)
+
+        preparator.charge_model = "read"
+        if args.charge_from_prop: 
+            preparator.charge_atom_prop = args.charge_from_prop[0]
+        else:
+            if ext=="mol2": 
+                preparator.charge_atom_prop = "_TriposPartialCharge"
+
     for mol in mol_supplier:
         if is_after_first and output.is_multimol == False:
             print("Processed only the first molecule of multiple molecule input.")

--- a/meeko/cli/mk_prepare_ligand.py
+++ b/meeko/cli/mk_prepare_ligand.py
@@ -81,7 +81,7 @@ def cmd_lineparser():
     io_group.add_argument(
         "--charge_from_prop",
         nargs="*",
-        help="set atom partial charges from the input file. The default is PartialCharge for SDF and _TriposPartialCharge for MOL2 unless overriden by a user defined property name. ",
+        help="set atom partial charges from an RDKit atom property based on the input file. The default is 'PartialCharge' for SDF and '_TriposPartialCharge' for MOL2 unless overriden by a user defined property name. ",
     )
     io_group.add_argument(
         "-o",
@@ -555,19 +555,20 @@ def main():
     )
     nr_failures = 0
     is_after_first = False
-    preparator = MoleculePreparation.from_config(config)
 
     if args.charge_from_prop is not None: 
         if args.charge_model != "read": 
             print('--charge_from_prop must be used with --charge_model "read"')
             sys.exit(1)
 
-        preparator.charge_model = "read"
+        config["charge_model"] = "read"
         if args.charge_from_prop: 
-            preparator.charge_atom_prop = args.charge_from_prop[0]
+            config["charge_atom_prop"] = args.charge_from_prop[0]
         else:
             if ext=="mol2": 
-                preparator.charge_atom_prop = "_TriposPartialCharge"
+                config["charge_atom_prop"] = "_TriposPartialCharge"
+
+    preparator = MoleculePreparation.from_config(config)
 
     for mol in mol_supplier:
         if is_after_first and output.is_multimol == False:

--- a/meeko/cli/mk_prepare_ligand.py
+++ b/meeko/cli/mk_prepare_ligand.py
@@ -79,8 +79,7 @@ def cmd_lineparser():
         help="set molecule name from RDKit/SDF property",
     )
     io_group.add_argument(
-        "--charge_from_prop",
-        nargs="*",
+        "--charge_atom_prop",
         help="set atom partial charges from an RDKit atom property based on the input file. The default is 'PartialCharge' for SDF and '_TriposPartialCharge' for MOL2 unless overriden by a user defined property name. ",
     )
     io_group.add_argument(
@@ -556,16 +555,15 @@ def main():
     nr_failures = 0
     is_after_first = False
 
-    if args.charge_from_prop is not None: 
-        if args.charge_model != "read": 
-            print(f'--charge_from_prop must be used with --charge_model "read", but the current charge_model is "{args.charge_model}". ')
+    if  config["charge_atom_prop"] is not None: 
+        if config["charge_model"] != "read": 
+            print(f'--charge_atom_prop must be used with --charge_model "read", but the current charge_model is "{config["charge_model"]}". ')
             sys.exit(1)
-
-        config["charge_model"] = "read"
-        config["charge_atom_prop"] = args.charge_from_prop[0] if args.charge_from_prop else "_TriposPartialCharge" if ext == "mol2" else None
-    else:
-        if ext=="mol2": 
-                config["charge_atom_prop"] = "_TriposPartialCharge"
+    elif config["charge_model"] == "read":  
+        if ext=="sdf":
+            config["charge_atom_prop"] = "PartialCharge"
+        elif ext=="mol2": 
+            config["charge_atom_prop"] = "_TriposPartialCharge"
 
     preparator = MoleculePreparation.from_config(config)
 

--- a/meeko/cli/mk_prepare_ligand.py
+++ b/meeko/cli/mk_prepare_ligand.py
@@ -51,11 +51,7 @@ def cmd_lineparser():
     if confargs.config_file is not None:
         with open(confargs.config_file) as f:
             c = json.load(f)
-        if any(key not in config for key in c): 
-            print(f"Error: Got unsupported keyword ({key}) for MoleculePreparation from the config file ({confargs.config_file}). ",
-                  file=sys.stderr,)
-            sys.exit(2)
-        config.update(c)
+            config.update(c)
 
     parser = (
         argparse.ArgumentParser()
@@ -80,10 +76,6 @@ def cmd_lineparser():
     io_group.add_argument(
         "--name_from_prop",
         help="set molecule name from RDKit/SDF property",
-    )
-    io_group.add_argument(
-        "--charge_atom_prop",
-        help="set atom partial charges from an RDKit atom property based on the input file. The default is 'PartialCharge' for SDF and '_TriposPartialCharge' for MOL2 unless overriden by a user defined property name. ",
     )
     io_group.add_argument(
         "-o",
@@ -226,6 +218,10 @@ def cmd_lineparser():
         default="gasteiger",
     )
     config_group.add_argument(
+        "--charge_atom_prop",
+        help="set atom partial charges from an RDKit atom property based on the input file. The default is 'PartialCharge' for SDF and '_TriposPartialCharge' for MOL2 unless overriden by a user defined property name. ",
+    )
+    config_group.add_argument(
         "--bad_charge_ok",
         help="NaN and Inf charges allowed in PDBQT",
         action="store_true",
@@ -300,8 +296,9 @@ def cmd_lineparser():
             sys.exit(2)
         args.reactive_smarts_idx -= 1  # convert from 1- to 0-index
 
-    for key in args.__dict__:
-        if key in config:
+    # command line arguments override config
+    for key in config:
+        if key in args.__dict__:
             config[key] = args.__dict__[key]
 
     if args.add_atom_types_json is not None:

--- a/meeko/cli/mk_prepare_ligand.py
+++ b/meeko/cli/mk_prepare_ligand.py
@@ -53,7 +53,7 @@ def cmd_lineparser():
         
         for key in c: 
             if key not in config: 
-                print(f"Got unsupported keyword ({key}) for MoleculePreparation from the config file ({confargs.config_file}). ",
+                print(f"Error: Got unsupported keyword ({key}) for MoleculePreparation from the config file ({confargs.config_file}). ",
                       file=sys.stderr,)
                 sys.exit(2)
         config.update(c)
@@ -289,14 +289,14 @@ def cmd_lineparser():
     # check reactive arguments
     if (args.reactive_smarts is None) != (args.reactive_smarts_idx is None):
         print(
-            "Arguments --reactive_smarts and --reactive_smarts_idx require each other",
+            "Error: Arguments --reactive_smarts and --reactive_smarts_idx require each other",
             file=sys.stderr,
         )
         sys.exit(2)
     elif args.reactive_smarts_idx is not None:
         if args.reactive_smarts_idx < 1:
             print(
-                "--reactive_smarts_idx is 1-indexed, but got %d"
+                "Error: --reactive_smarts_idx is 1-indexed, but got %d"
                 % args.reactive_smarts_idx,
                 file=sys.stderr,
             )
@@ -342,14 +342,14 @@ def cmd_lineparser():
         sys.exit(2)
     is_covalent = num_required_covalent_args == 3
     if is_covalent and not _has_prody:
-        msg = "Covalent docking requires Prody which is not installed." + eol
+        msg = "Error: Covalent docking requires Prody which is not installed." + eol
         msg += "Installable from PyPI (pip install prody) or conda-forge (micromamba install prody)"
         print(_prody_import_error, file=sys.stderr)
         print(msg)
         sys.exit(2)
     if min(args.tether_smarts_indices) < 1:
         print(
-            "--tether_smarts_indices is 1-indexed, all values must be greater than zero",
+            "Error: --tether_smarts_indices is 1-indexed, all values must be greater than zero",
             file=sys.stderr,
         )
         sys.exit(2)
@@ -517,7 +517,7 @@ def main():
     }
     if not ext in parsers:
         print(
-            "*ERROR* Format [%s] not in supported formats [%s]"
+            "Error: Format [%s] not in supported formats [%s]"
             % (ext, "/".join(list(parsers.keys())))
         )
         sys.exit(1)
@@ -560,7 +560,7 @@ def main():
 
     if  config["charge_atom_prop"] is not None: 
         if config["charge_model"] != "read": 
-            print(f'--charge_atom_prop must be used with --charge_model "read", but the current charge_model is "{config["charge_model"]}". ',
+            print(f'Error: --charge_atom_prop must be used with --charge_model "read", but the current charge_model is "{config["charge_model"]}". ',
                   file=sys.stderr,)
             sys.exit(1)
     elif config["charge_model"] == "read":  

--- a/meeko/cli/mk_prepare_ligand.py
+++ b/meeko/cli/mk_prepare_ligand.py
@@ -58,7 +58,6 @@ def cmd_lineparser():
                 sys.exit(2)
         config.update(c)
 
-# region CLIArgParser
     parser = (
         argparse.ArgumentParser()
     )  # parents=[conf_parser]) # parents shows --config_file in help msg
@@ -282,7 +281,6 @@ def cmd_lineparser():
         help="indices (1-based) of the SMARTS atoms that will be attached (default: 1 2)",
     )
 
-# endregion
     parser.set_defaults(**config)
     args = parser.parse_args(remaining_argv)
 

--- a/meeko/cli/mk_prepare_ligand.py
+++ b/meeko/cli/mk_prepare_ligand.py
@@ -558,14 +558,13 @@ def main():
 
     if args.charge_from_prop is not None: 
         if args.charge_model != "read": 
-            print('--charge_from_prop must be used with --charge_model "read"')
+            print(f'--charge_from_prop must be used with --charge_model "read", but the current charge_model is "{args.charge_model}". ')
             sys.exit(1)
 
         config["charge_model"] = "read"
-        if args.charge_from_prop: 
-            config["charge_atom_prop"] = args.charge_from_prop[0]
-        else:
-            if ext=="mol2": 
+        config["charge_atom_prop"] = args.charge_from_prop[0] if args.charge_from_prop else "_TriposPartialCharge" if ext == "mol2" else None
+    else:
+        if ext=="mol2": 
                 config["charge_atom_prop"] = "_TriposPartialCharge"
 
     preparator = MoleculePreparation.from_config(config)

--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from collections import defaultdict
 from dataclasses import asdict, dataclass, field
 import json
+from os import linesep as eol
 import sys
 import warnings
 
@@ -1574,6 +1575,7 @@ class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolkit):
         keep_chorded_rings: bool
         keep_equivalent_rings: bool
         compute_gasteiger_charges: bool
+        read_charges_from_prop: str
         conformer_id: int
 
         Returns
@@ -1727,10 +1729,10 @@ class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolkit):
                     f"Invalid value for read_charges_from_prop: expected a string (str), but got {type(read_charges_from_prop).__name__} instead. "
                 )
             if not read_charges_from_prop: 
-                read_charges_from_prop = "partial_charge"
+                read_charges_from_prop = "_TriposPartialCharge"
                 raise Warning(
                     "The charge_model of MoleculePreparation is set to be 'read', but a valid charge_propname is not given. " + eol + 
-                    "The default property name ('partial_charge') will be used. " 
+                    "The default property name ('_TriposPartialCharge') will be used. " 
                 )
             charges = [float(atom.GetProp(read_charges_from_prop)) for atom in self.mol.GetAtoms()]
         else:

--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -1481,7 +1481,7 @@ class MoleculeSetupExternalToolkit(ABC):
         return index
 
     @abstractmethod
-    def init_atom(self, compute_gasteiger_charges, coords, read_charges_from_prop):
+    def init_atom(self, compute_gasteiger_charges, read_charges_from_prop, coords):
         pass
 
     @abstractmethod

--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -1732,7 +1732,7 @@ class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolkit):
                     "The charge_model of MoleculePreparation is set to be 'read', but a valid charge_propname is not given. " + eol + 
                     "The default property name ('partial_charge') will be used. " 
                 )
-            charges = [atom.GetProp(read_charges_from_prop) for atom in self.mol.GetAtoms()]
+            charges = [float(atom.GetProp(read_charges_from_prop)) for atom in self.mol.GetAtoms()]
         else:
             charges = [0.0] * self.mol.GetNumAtoms()
         # register atom

--- a/meeko/preparation.py
+++ b/meeko/preparation.py
@@ -166,10 +166,10 @@ class MoleculePreparation:
             )
         if self.charge_model=="read":
             if not self.charge_propname: 
-                self.charge_propname = "_TriposPartialCharge"
-                raise Warning(
+                self.charge_propname = "PartialCharge"
+                warnings.warn(
                     "The charge_model of MoleculePreparation is set to be 'read', but a valid charge_propname is not given. " + eol + 
-                    "The default property name ('_TriposPartialCharge') will be used. " 
+                    "The default atom property ('PartialCharge') will be used. " 
                 )
             elif not isinstance(self.charge_propname, str): 
                 raise ValueError(

--- a/meeko/preparation.py
+++ b/meeko/preparation.py
@@ -160,9 +160,8 @@ class MoleculePreparation:
 
         if self.charge_model!="read" and self.charge_atom_prop: 
             raise ValueError(
-                "A charge_atom_prop (%s) is given to MoleculePreparation but its current charge_model is %s. " + eol + 
+                f"A charge_atom_prop ({charge_atom_prop}) is given to MoleculePreparation but its current charge_model is {charge_model}. " + eol + 
                 "To read charges from atom properties in the input mol, set charge_model to 'read' and name the property as 'charge_atom_prop'. " 
-                % (charge_atom_prop, charge_model)
             )
         if self.charge_model=="read":
             if not self.charge_atom_prop: 

--- a/meeko/preparation.py
+++ b/meeko/preparation.py
@@ -86,6 +86,7 @@ class MoleculePreparation:
         input_offatom_params=None,
         load_offatom_params=None,
         charge_model="gasteiger",
+        charge_propname=None,
         dihedral_model=None,
         reactive_smarts=None,
         reactive_smarts_idx=None,
@@ -147,7 +148,7 @@ class MoleculePreparation:
             raise NotImplementedError("load_offatom_params not implemented")
         self.load_offatom_params = load_offatom_params
 
-        allowed_charge_models = ["espaloma", "gasteiger", "zero"]
+        allowed_charge_models = ["espaloma", "gasteiger", "zero", "read"]
         if charge_model not in allowed_charge_models:
             raise ValueError(
                 "unrecognized charge_model: %s, allowed options are: %s"
@@ -155,6 +156,14 @@ class MoleculePreparation:
             )
 
         self.charge_model = charge_model
+        self.charge_propname = charge_propname
+
+        if self.charge_model!="read" and self.charge_propname: 
+            raise ValueError(
+                "A charge_propname (%s) is given to MoleculePreparation but its current charge_model is %s. " + eol + 
+                "To read charges from atom properties in the input mol, set charge_model to 'read' and name the property in 'charge_propname'. " + eol
+                % (charge_propname, charge_model)
+            )
 
         allowed_dihedral_models = [None, "openff", "espaloma"]
         if dihedral_model in (None, "espaloma"):
@@ -490,7 +499,8 @@ class MoleculePreparation:
             mol,
             keep_chorded_rings=self.keep_chorded_rings,
             keep_equivalent_rings=self.keep_equivalent_rings,
-            assign_charges=self.charge_model == "gasteiger",
+            compute_gasteiger_charges=self.charge_model == "gasteiger",
+            read_charges_from_prop=self.charges_propname,
             conformer_id=conformer_id,
         )
 

--- a/meeko/preparation.py
+++ b/meeko/preparation.py
@@ -169,7 +169,7 @@ class MoleculePreparation:
                 self.charge_atom_prop = "PartialCharge"
                 warnings.warn(
                     "The charge_model of MoleculePreparation is set to be 'read', but a valid charge_atom_prop is not given. " + eol + 
-                    "The default atom property ('PartialCharge') will be used. " 
+                    "The default atom property ('PartialCharge') will be used. "
                 )
             elif not isinstance(self.charge_atom_prop, str): 
                 raise ValueError(

--- a/meeko/preparation.py
+++ b/meeko/preparation.py
@@ -161,10 +161,21 @@ class MoleculePreparation:
         if self.charge_model!="read" and self.charge_propname: 
             raise ValueError(
                 "A charge_propname (%s) is given to MoleculePreparation but its current charge_model is %s. " + eol + 
-                "To read charges from atom properties in the input mol, set charge_model to 'read' and name the property in 'charge_propname'. " + eol
+                "To read charges from atom properties in the input mol, set charge_model to 'read' and name the property in 'charge_propname'. " 
                 % (charge_propname, charge_model)
             )
-
+        if self.charge_model=="read":
+            if not self.charge_propname: 
+                self.charge_propname = "partial_charge"
+                raise Warning(
+                    "The charge_model of MoleculePreparation is set to be 'read', but a valid charge_propname is not given. " + eol + 
+                    "The default property name ('partial_charge') will be used. " 
+                )
+            elif not isinstance(self.charge_propname, str): 
+                raise ValueError(
+                    f"Invalid value for charge_propname: expected a string (str), but got {type(self.charge_propname).__name__} instead. "
+                )
+        
         allowed_dihedral_models = [None, "openff", "espaloma"]
         if dihedral_model in (None, "espaloma"):
             dihedral_list = []
@@ -500,7 +511,7 @@ class MoleculePreparation:
             keep_chorded_rings=self.keep_chorded_rings,
             keep_equivalent_rings=self.keep_equivalent_rings,
             compute_gasteiger_charges=self.charge_model == "gasteiger",
-            read_charges_from_prop=self.charges_propname,
+            read_charges_from_prop=self.charge_propname,
             conformer_id=conformer_id,
         )
 
@@ -510,7 +521,7 @@ class MoleculePreparation:
         AtomTyper.type_everything(
             setup,
             self.atom_params,
-            self.charge_model,
+            self.charge_model, # charge_model is not accessed in type_everything
             self.offatom_params,
             self.dihedral_params,
         )

--- a/meeko/preparation.py
+++ b/meeko/preparation.py
@@ -166,10 +166,10 @@ class MoleculePreparation:
             )
         if self.charge_model=="read":
             if not self.charge_propname: 
-                self.charge_propname = "partial_charge"
+                self.charge_propname = "_TriposPartialCharge"
                 raise Warning(
                     "The charge_model of MoleculePreparation is set to be 'read', but a valid charge_propname is not given. " + eol + 
-                    "The default property name ('partial_charge') will be used. " 
+                    "The default property name ('_TriposPartialCharge') will be used. " 
                 )
             elif not isinstance(self.charge_propname, str): 
                 raise ValueError(

--- a/meeko/preparation.py
+++ b/meeko/preparation.py
@@ -86,7 +86,7 @@ class MoleculePreparation:
         input_offatom_params=None,
         load_offatom_params=None,
         charge_model="gasteiger",
-        charge_propname=None,
+        charge_atom_prop=None,
         dihedral_model=None,
         reactive_smarts=None,
         reactive_smarts_idx=None,
@@ -156,24 +156,24 @@ class MoleculePreparation:
             )
 
         self.charge_model = charge_model
-        self.charge_propname = charge_propname
+        self.charge_atom_prop = charge_atom_prop
 
-        if self.charge_model!="read" and self.charge_propname: 
+        if self.charge_model!="read" and self.charge_atom_prop: 
             raise ValueError(
-                "A charge_propname (%s) is given to MoleculePreparation but its current charge_model is %s. " + eol + 
-                "To read charges from atom properties in the input mol, set charge_model to 'read' and name the property in 'charge_propname'. " 
-                % (charge_propname, charge_model)
+                "A charge_atom_prop (%s) is given to MoleculePreparation but its current charge_model is %s. " + eol + 
+                "To read charges from atom properties in the input mol, set charge_model to 'read' and name the property as 'charge_atom_prop'. " 
+                % (charge_atom_prop, charge_model)
             )
         if self.charge_model=="read":
-            if not self.charge_propname: 
-                self.charge_propname = "PartialCharge"
+            if not self.charge_atom_prop: 
+                self.charge_atom_prop = "PartialCharge"
                 warnings.warn(
-                    "The charge_model of MoleculePreparation is set to be 'read', but a valid charge_propname is not given. " + eol + 
+                    "The charge_model of MoleculePreparation is set to be 'read', but a valid charge_atom_prop is not given. " + eol + 
                     "The default atom property ('PartialCharge') will be used. " 
                 )
-            elif not isinstance(self.charge_propname, str): 
+            elif not isinstance(self.charge_atom_prop, str): 
                 raise ValueError(
-                    f"Invalid value for charge_propname: expected a string (str), but got {type(self.charge_propname).__name__} instead. "
+                    f"Invalid value for charge_atom_prop: expected a string (str), but got {type(self.charge_atom_prop).__name__} instead. "
                 )
         
         allowed_dihedral_models = [None, "openff", "espaloma"]
@@ -511,7 +511,7 @@ class MoleculePreparation:
             keep_chorded_rings=self.keep_chorded_rings,
             keep_equivalent_rings=self.keep_equivalent_rings,
             compute_gasteiger_charges=self.charge_model == "gasteiger",
-            read_charges_from_prop=self.charge_propname,
+            read_charges_from_prop=self.charge_atom_prop,
             conformer_id=conformer_id,
         )
 


### PR DESCRIPTION
This is for #224. 

`Chem.MolFromMol2File` in RDKit parses partial charges into atom property name `_TriposPartialCharge`. This PR simply reads the charges from atom property at the point [init_atom](https://github.com/forlilab/Meeko/blob/07a38f8bac4aa9eef4ef30aa8e67475b15d517aa/meeko/molsetup.py#L1662). 

An additional attribute, `charge_propname`, is added to `MoleculePreparation`, and it needs to be used with option `charge_model = "read"`. The default is `_TriposPartialCharge`. 
The corresponding argument `read_charges_from_prop` is also added to the `from_mol` method for RDKitMoleculeSetup to be accessed at a lower level. It must not be conflicting with argument `compute_gasteiger_charges` (formerly `assign_charges`). 
Some error messages for conflict handling are added. 

Notes: 

- The total charge from the mol2 file will be preserved (i.e. if the total charge is non-integer at the beginning, the sum of the output charges will be the same). 
- In addition to `_TriposPartialCharge`, any other named RDKit Atom attribute can be used as the source of charges. 
- The RDKit parser needs the MOL2 file to have valid SYBYL atom types, which is not the case for some definition MOL2 files in/from Amber/AmberTools. 

Python usage example: 
[212163792.mol2.txt](https://github.com/user-attachments/files/17967004/212163792.mol2.txt)

```py
from meeko import MoleculePreparation
from meeko import PDBQTWriterLegacy
from rdkit import Chem

input_filename = "212163792.mol2"
output_filename = "212163792.pdbqt"
mol = Chem.MolFromMol2File(input_filename, removeHs=False)
mk_prep = MoleculePreparation(charge_model="read", charge_atom_prop="_TriposPartialCharge")
molsetup_list = mk_prep(mol)
molsetup = molsetup_list[0]
pdbqt_string = PDBQTWriterLegacy.write_string(molsetup)

with open(output_filename, "w") as f:
    f.write(pdbqt_string[0])
```