### PR TITLE
Use dynamic entry to avoid circular import in generated console scripts when installed via conda

### DIFF
--- a/meeko/cli/dynamic_entry.py
+++ b/meeko/cli/dynamic_entry.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# wrapper functions for each console script
+
+def prepare_receptor():
+    import importlib
+    main = importlib.import_module('meeko.cli.mk_prepare_receptor').main
+    main()
+
+def prepare_ligand():
+    import importlib
+    main = importlib.import_module('meeko.cli.mk_prepare_ligand').main
+    main()
+
+def export():
+    import importlib
+    main = importlib.import_module('meeko.cli.mk_export').main
+    main()

--- a/setup.py
+++ b/setup.py
@@ -54,9 +54,9 @@ setup(
     ],
     entry_points={
         'console_scripts': [
-            'mk_export.py=meeko.cli.mk_export:main',
-            'mk_prepare_ligand.py=meeko.cli.mk_prepare_ligand:main',
-            'mk_prepare_receptor.py=meeko.cli.mk_prepare_receptor:main'
-        ]
+            'mk_prepare_receptor.py = meeko.cli.dynamic_entry:prepare_receptor',
+            'mk_prepare_ligand.py = meeko.cli.dynamic_entry:prepare_ligand',
+            'mk_export.py = meeko.cli.dynamic_entry:export',
+        ],
     }
 )


### PR DESCRIPTION
This is for #260, it seems to work, but might not be the best solution.. 