### PR TITLE
Format string in output file with plain line-ending character instead of os.linesep

### DIFF
--- a/meeko/cli/mk_export.py
+++ b/meeko/cli/mk_export.py
@@ -7,7 +7,7 @@ import argparse
 import gzip
 import pathlib
 import sys
-from os import linesep as eol
+eol="\n"
 import warnings
 import copy
 import numpy as np

--- a/meeko/cli/mk_prepare_ligand.py
+++ b/meeko/cli/mk_prepare_ligand.py
@@ -7,7 +7,7 @@ import argparse
 from datetime import datetime
 import io
 import os
-from os import linesep as eol
+eol="\n"
 import sys
 import json
 import tarfile

--- a/meeko/cli/mk_prepare_receptor.py
+++ b/meeko/cli/mk_prepare_receptor.py
@@ -3,7 +3,7 @@
 import argparse
 import json
 import math
-from os import linesep as eol
+eol="\n"
 import pathlib
 import sys
 

--- a/meeko/gridbox.py
+++ b/meeko/gridbox.py
@@ -1,4 +1,4 @@
-from os import linesep as eol
+eol="\n"
 import pathlib
 import numpy as np
 

--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from collections import defaultdict
 from dataclasses import asdict, dataclass, field
 import json
-from os import linesep as eol
+eol="\n"
 import sys
 import warnings
 from typing import Union

--- a/meeko/polymer.py
+++ b/meeko/polymer.py
@@ -3,7 +3,7 @@ import json
 import logging
 import traceback
 from importlib.resources import files
-from os import linesep as eol
+eol="\n"
 from sys import exc_info
 from typing import Union
 from typing import Optional

--- a/meeko/preparation.py
+++ b/meeko/preparation.py
@@ -6,7 +6,7 @@
 
 from inspect import signature
 import json
-from os import linesep as eol
+eol="\n"
 import pathlib
 import warnings
 

--- a/meeko/receptor_pdbqt.py
+++ b/meeko/receptor_pdbqt.py
@@ -6,7 +6,7 @@
 
 from collections import defaultdict
 import json
-from os import linesep as eol
+eol="\n"
 
 import numpy as np
 from scipy import spatial

--- a/meeko/writer.py
+++ b/meeko/writer.py
@@ -7,7 +7,7 @@
 import sys
 import json
 import math
-from os import linesep as eol
+eol="\n"
 
 import numpy as np
 from rdkit import Chem


### PR DESCRIPTION
The issue only affects Windows PowerShell. In some files written by Meeko, each line has double the line-ending characters. This is likely because the Python built-in function `f.open()` by default translates '\r\n' (os.linesep on Windows) to '\r\r\n' when writing the file, which will be read as '\n\n' when the file is re-opened. 

https://docs.python.org/3/library/functions.html#open

> When writing output to the stream, if newline is None, any '\n' characters written are translated to the system default line separator, [os.linesep](https://docs.python.org/3/library/os.html#os.linesep). If newline is '' or '\n', no translation takes place. If newline is any of the other legal values, any '\n' characters written are translated to the given string. 

This PR replaces all eol by the plain line-ending character '\n'. Another possible solution is to always write without translation, i.e. f.open(newline='') but that isn't the default. Thanks to Nicole Benson (Fuchs lab, OSU) for bringing this to our attention. 