### PR TITLE
Catch prepare errors without interrupting batch processing

### DIFF
--- a/meeko/cli/mk_prepare_ligand.py
+++ b/meeko/cli/mk_prepare_ligand.py
@@ -637,7 +637,15 @@ def main():
                         print(error_msg, file=sys.stderr)
 
         else:
-            molsetups = preparator.prepare(mol, rename_atoms=args.rename_atoms)
+            try: 
+                molsetups = preparator.prepare(mol, rename_atoms=args.rename_atoms)
+            except Exception as error_msg: 
+                nr_failures += 1
+                this_mol_had_failure = True
+                print(error_msg, file=sys.stderr)
+                input_mol_with_failure += int(this_mol_had_failure)
+                continue
+
             if len(molsetups) > 1:
                 output.is_multimol = True
             suffixes = output.get_suffixes(molsetups)


### PR DESCRIPTION
This is a quick fix to catch prepare errors without interrupting batch processing, using try/except as proposed in #271. 