### PR TITLE
Update required Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=['numpy>=1.18', "rdkit", "scipy", "gemmi"],
-    python_requires='>=3.9, <3.12',
+    python_requires='>=3.9',
     license="LGPL-2.1",
     keywords=["molecular modeling", "drug design",
             "docking", "autodock"],


### PR DESCRIPTION
Dropped the Python version upper limit as is usual to actively maintained projects. It is now installable in Python 3.13.