### PR TITLE
Add support to PDB ligands on CLI

### DIFF
--- a/meeko/cli/mk_prepare_ligand.py
+++ b/meeko/cli/mk_prepare_ligand.py
@@ -503,6 +503,7 @@ def main():
     ext = ext[1:].lower()
     if backend == "rdkit":
         parsers = {
+            "pdb": rdkitutils.PdbMolSupplier,
             "sdf": Chem.SDMolSupplier,
             "mol2": rdkitutils.Mol2MolSupplier,
             "mol": Chem.SDMolSupplier,
@@ -575,7 +576,7 @@ def main():
             else:
                 continue  # TODO log this event
         else:
-            name = mol.GetProp("_Name")
+            name = mol.GetPropsAsDict().get("_Name", input_fname)
         is_after_first = True
 
         if is_covalent:
@@ -610,6 +611,8 @@ def main():
                         print(error_msg, file=sys.stderr)
 
         else:
+            if ext == "pdb":
+                mol = Chem.rdmolops.AddHs(mol)
             molsetups = preparator.prepare(mol)
             if len(molsetups) > 1:
                 output.is_multimol = True

--- a/meeko/utils/rdkitutils.py
+++ b/meeko/utils/rdkitutils.py
@@ -94,6 +94,32 @@ class Mol2MolSupplier:
         self.buff = [line]
         return mol
 
+class PdbMolSupplier:
+    """RDKit Mol2 molecule supplier.
+    Parameters
+        sanitize: perform RDKit sanitization of Mol2 molecule"""
+
+    def __init__(
+        self, filename, sanitize=True, removeHs=False, cleanupSubstructures=True
+    ):
+        self.filename = filename
+        self._opts = {
+            "sanitize": sanitize,
+            "removeHs": removeHs,
+        }
+        self.done = False
+        
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        """iterator step"""
+        if not self.done:
+            self.done = True
+            return Chem.rdmolfiles.MolFromPDBFile(self.filename, **self._opts)
+        else:
+            raise StopIteration
+    
 class AtomField:
     """Stores data parsed from PDB or mmCIF"""
 


### PR DESCRIPTION
Add support to mk_prepare_ligand.py read PDB files.

They're crystallographic ligands  from PDB and PDBBind. Because of this, they have no hydrogen and must be added.

It works on my use case, but maybe someone have also PDB files for micro-molecules with explicit hydrogens already into.