### PR TITLE
Small Bugfixes in closed PR #259

### DIFF
--- a/meeko/chemtempgen.py
+++ b/meeko/chemtempgen.py
@@ -395,28 +395,31 @@ class ChemicalComponent:
                            'value_order', # bond order
                            ]
         bond_table = block.find(bond_category, bond_attributes)
-        bond_cols = {attr: bond_table.find_column(f"{bond_category}{attr}") for attr in bond_attributes}
+        
+        # If bond table is empty (single-atom residues), skip bond creation
+        if bond_table: 
+            bond_cols = {attr: bond_table.find_column(f"{bond_category}{attr}") for attr in bond_attributes}
 
-        # Connect atoms by bonds
-        bond_type_mapping = {
-            'SING': Chem.BondType.SINGLE,
-            'DOUB': Chem.BondType.DOUBLE,
-            'TRIP': Chem.BondType.TRIPLE,
-            'AROM': Chem.BondType.AROMATIC
-        }
-        bond_types = bond_cols['value_order']
+            # Connect atoms by bonds
+            bond_type_mapping = {
+                'SING': Chem.BondType.SINGLE,
+                'DOUB': Chem.BondType.DOUBLE,
+                'TRIP': Chem.BondType.TRIPLE,
+                'AROM': Chem.BondType.AROMATIC
+            }
+            bond_types = bond_cols['value_order']
 
-        for bond_i, bond_type in enumerate(bond_types):
-            rwmol.AddBond(name_to_idx_mapping[bond_cols['atom_id_1'][bond_i].strip('"')], 
-                          name_to_idx_mapping[bond_cols['atom_id_2'][bond_i].strip('"')], 
-                          bond_type_mapping.get(bond_type, Chem.BondType.UNSPECIFIED))
+            for bond_i, bond_type in enumerate(bond_types):
+                rwmol.AddBond(name_to_idx_mapping[bond_cols['atom_id_1'][bond_i].strip('"')], 
+                            name_to_idx_mapping[bond_cols['atom_id_2'][bond_i].strip('"')], 
+                            bond_type_mapping.get(bond_type, Chem.BondType.UNSPECIFIED))
 
-        # Try recharging mol (for metals)
-        try:
-            rwmol = recharge(rwmol)
-        except Exception as e:
-            logger.error(f"Failed to recharge rdkitmol. Error: {e} -> template for {resname} will be None. ")
-            return None
+            # Try recharging mol (for metals)
+            try:
+                rwmol = recharge(rwmol)
+            except Exception as e:
+                logger.error(f"Failed to recharge rdkitmol. Error: {e} -> template for {resname} will be None. ")
+                return None
 
         # Finish eidting mol 
         try:    

--- a/meeko/cli/mk_prepare_receptor.py
+++ b/meeko/cli/mk_prepare_receptor.py
@@ -634,7 +634,7 @@ def main():
         with open(fn, "w") as f:
             f.write(polymer.to_pdb())
         written_files_log["filename"].append(fn)
-        written_files_log["description"].append("receptor")
+        written_files_log["description"].append("processed receptor PDB")
     
     if args.write_pdbqt is not None:
         if args.write_pdbqt:

--- a/meeko/cli/mk_prepare_receptor.py
+++ b/meeko/cli/mk_prepare_receptor.py
@@ -630,7 +630,7 @@ def main():
         if args.write_pdb:
             fn = args.write_pdb[0]
         else:  
-            fn = str(outpath) + ".pdb"
+            raise ValueError("--write_pdb requires a filename")
         with open(fn, "w") as f:
             f.write(polymer.to_pdb())
         written_files_log["filename"].append(fn)

--- a/meeko/cli/mk_prepare_receptor.py
+++ b/meeko/cli/mk_prepare_receptor.py
@@ -627,7 +627,10 @@ def main():
         written_files_log["description"].append("parameterized receptor")
     
     if args.write_pdb is not None:
-        fn = args.write_pdb[0]
+        if args.write_pdb:
+            fn = args.write_pdb[0]
+        else:  
+            fn = str(outpath) + ".pdb"
         with open(fn, "w") as f:
             f.write(polymer.to_pdb())
         written_files_log["filename"].append(fn)

--- a/meeko/polymer.py
+++ b/meeko/polymer.py
@@ -1831,7 +1831,7 @@ class Polymer(BaseJSONParsable):
 
         pdbout = ""
         atom_count = 0
-        pdb_line = "{:6s}{:5d} {:^4s} {:3s} {:1s}{:4d}{:1s}   {:8.3f}{:8.3f}{:8.3f}                       {:2s} "
+        pdb_line = "{:6s}{:5d} {:^4s} {:3s} {:1s}{:4d}{:1s}   {:8.3f}{:8.3f}{:8.3f}                      {:2s} "
         pdb_line += eol
         for res_id in self.get_valid_monomers():
             rdkit_mol = self.monomers[res_id].rdkit_mol

--- a/meeko/polymer.py
+++ b/meeko/polymer.py
@@ -1831,7 +1831,7 @@ class Polymer(BaseJSONParsable):
 
         pdbout = ""
         atom_count = 0
-        pdb_line = "{:6s}{:5d} {:^4s} {:3s} {:1s}{:4d}{:1s}   {:8.3f}{:8.3f}{:8.3f}                      {:2s} "
+        pdb_line = "{:6s}{:5d} {:^4s} {:3s} {:1s}{:4d}{:1s}   {:8.3f}{:8.3f}{:8.3f}                      {:>2s} "
         pdb_line += eol
         for res_id in self.get_valid_monomers():
             rdkit_mol = self.monomers[res_id].rdkit_mol


### PR DESCRIPTION
1- Allow single atom residues in template generation

~~2- Bugfix for option `--write_pdb` in CLI script mk_prepare_receptor~~

This is not a bug, but a behavior I didn't fully understand. 

Before: 

```
(mk_dev) amyhe@Amys-MBP ~/Downloads % mk_prepare_receptor.py -i three_res.pdb -o three_res_out --write_pdb
@> 4412 atoms and 1 coordinate set(s) were parsed in 0.02s.
Traceback (most recent call last):
  File "/Users/amyhe/micromamba/envs/mk_dev/bin/mk_prepare_receptor.py", line 33, in <module>
    sys.exit(load_entry_point('meeko', 'console_scripts', 'mk_prepare_receptor.py')())
  File "/Users/amyhe/Desktop/0_forks/Meeko/meeko/cli/mk_prepare_receptor.py", line 630, in main
    fn = args.write_pdb[0]
IndexError: list index out of range
```

3- Corrected polymer.to_pdb() that wrote element in columns 78-79

Before we wrote: 

```
ATOM      1  CL  CL  B1464      36.135  12.381  -3.884                       Cl 
```

After (expected):

```
ATOM      1  CL  CL  B1464      36.135  12.381  -3.884                      Cl 
```