### PR TITLE
Forgive extra interresidue bonds

### DIFF
--- a/meeko/cli/mk_prepare_receptor.py
+++ b/meeko/cli/mk_prepare_receptor.py
@@ -10,8 +10,6 @@ import sys
 import numpy as np
 
 from meeko.reactive import atom_name_to_molsetup_index, assign_reactive_types_by_index
-from meeko.polymer import residue_chem_templates_json_decoder
-from meeko import ResidueChemTemplatesEncoder
 from meeko import PDBQTMolecule
 from meeko import RDKitMolCreate
 from meeko import MoleculePreparation
@@ -186,7 +184,6 @@ def get_args():
                                   "the specified cache file and updates may be made to the same file in a cumulative manner. " 
                               ), 
                               nargs = "?", 
-                              default = False, 
     )
     config_group.add_argument("--mk_config", help="[.json]", metavar="JSON_FILENAME")
     config_group.add_argument(
@@ -297,7 +294,7 @@ def get_args():
         print(eol + msg, file=sys.stderr)
         sys.exit(2)
 
-    if args.cache_templates is not False: 
+    if args.cache_templates is not None:
         if not args.cache_templates:
             print(f"--cache_templates is turned on, but a name is not provided. The default filename ($HOME/.meeko_residue_chem_templates_cached.json) will be used. ", 
                 file=sys.stderr)
@@ -523,11 +520,10 @@ def main():
         cache_file = args.cache_templates
 
         try:
+            print(f"reading {cache_file=}")
             with open(cache_file, "r") as f:
                 json_str = f.read()
-            templates = json.loads(
-                json_str, object_hook=residue_chem_templates_json_decoder
-            )
+            templates = ResidueChemTemplates.from_json(json_str)
         except FileNotFoundError:
             print(f"WARNING: specified cache file for residue chem templates not found. " + eol +
                   f"The initial templates will be default, and a new cache will be created at {cache_file}. ", 

--- a/meeko/cli/mk_prepare_receptor.py
+++ b/meeko/cli/mk_prepare_receptor.py
@@ -184,6 +184,7 @@ def get_args():
                                   "the specified cache file and updates may be made to the same file in a cumulative manner. " 
                               ), 
                               nargs = "?", 
+                              default=False,
     )
     config_group.add_argument("--mk_config", help="[.json]", metavar="JSON_FILENAME")
     config_group.add_argument(
@@ -294,8 +295,8 @@ def get_args():
         print(eol + msg, file=sys.stderr)
         sys.exit(2)
 
-    if args.cache_templates is not None:
-        if not args.cache_templates:
+    if args.cache_templates is not False:
+        if args.cache_templates is None:
             print(f"--cache_templates is turned on, but a name is not provided. The default filename ($HOME/.meeko_residue_chem_templates_cached.json) will be used. ", 
                 file=sys.stderr)
             default_cache_fn = ".meeko_residue_chem_templates_cached.json"
@@ -516,11 +517,10 @@ def main():
     mk_prep = MoleculePreparation.from_config(mk_config)
     
     # load templates for mapping
-    if args.cache_templates is not None:
+    if args.cache_templates:
         cache_file = args.cache_templates
 
         try:
-            print(f"reading {cache_file=}")
             with open(cache_file, "r") as f:
                 json_str = f.read()
             templates = ResidueChemTemplates.from_json(json_str)
@@ -611,8 +611,8 @@ def main():
     
     
     # Update residue chem template cache
-    if args.cache_templates is not None: 
-        updated_templates_json_strs = json.dumps(templates, cls=ResidueChemTemplatesEncoder)
+    if args.cache_templates: 
+        updated_templates_json_strs = templates.to_json()
         with open(cache_file, 'w') as f:
             f.write(updated_templates_json_strs)
     

--- a/meeko/polymer.py
+++ b/meeko/polymer.py
@@ -1577,7 +1577,6 @@ class Polymer(BaseJSONParsable):
                         or all_stats["heavy_excess"][i]
                         or (not set(all_stats["H_excess"][i]) <= set(candidate_templates[i].link_labels) and not excess_H_ok)
                         or not all_stats["bonded_atoms_missing"][i] <= auto_blunt
-                        or len(all_stats["bonded_atoms_excess"][i])
                     ):
                         continue
                     passed.append(i)
@@ -1590,7 +1589,6 @@ class Polymer(BaseJSONParsable):
                         or all_stats["heavy_excess"][i]
                         or (all_stats["H_excess"][i] and not excess_H_ok)
                         or len(all_stats["bonded_atoms_missing"][i])
-                        or len(all_stats["bonded_atoms_excess"][i])
                     ):
                         continue
                     if i not in passed:

--- a/meeko/polymer.py
+++ b/meeko/polymer.py
@@ -1457,6 +1457,7 @@ class Polymer(BaseJSONParsable):
             "chosen_by_fewest_missing_H": {},
             "chosen_by_default": {},
             "matched_with_H_anomaly": {},
+            "matched_with_excess_bond": [],
             "no_match": [],
             "no_mol": [],
             "msg": "",
@@ -1657,6 +1658,10 @@ class Polymer(BaseJSONParsable):
                     template_key, 
                     {"H_miss": H_miss, "H_excess": len(H_excess)}
                 )
+            bond_excess = all_stats["bonded_atoms_excess"][index]
+            if bond_excess:
+                log["matched_with_excess_bond"].append(residue_key)
+                logger.warning(f"matched with excess inter-residue bond(s): {residue_key}")
 
             if template is None:
                 rdkit_mol = None


### PR DESCRIPTION
@pietscio is preparing receptors from @nbruciaferri  that have clashes between sidechains, and @sforli suggested to forgive excess bonds. I think this should even be made default as I can't think of a scenario in the desired behavior for a system with clashes isn't to get a warning but still process the structure. All existing tests pass. @rwxayheee can you think of a possible problem with this? We discussed some concepts in #211 but I don't remember ever discussing forgiving excess inter-residue bonds.

There's minor fixes for mk_prepare_receptor.py included herein.