### PR TITLE
rigidify triple bonds (rigidify single bonds in single-triple-single)

### DIFF
--- a/meeko/bondtyper.py
+++ b/meeko/bondtyper.py
@@ -36,6 +36,19 @@ class BondTyperLegacy:
                 num_amides_removed += 1
         assert num_amides_originally == num_amides_removed + len(amide_bonds)
 
+        triple_bonds = [(x[0], x[1]) for x in setup.find_pattern("[*]#[*]")]
+        single_triple_single = [
+            (x[0], x[1], x[2], x[3]) for x in setup.find_pattern("[*]-[*]#[*]-[*]")
+        ]
+        single_to_rigidify = []
+        for i, j, k, m in single_triple_single:
+            triple_bonds.remove((j, k))
+            single_to_rigidify.append((i, j))
+            single_to_rigidify.append((k, m))
+        # fully rigidify nitrile and alike
+        single_to_rigidify.extend(
+            [(x[0], x[1]) for x in setup.find_pattern("[*]-[*]#[*X1]")]
+        )
         to_rigidify = set()
         n_smarts = len(rigidify_bonds_smarts)
         assert n_smarts == len(rigidify_bonds_indices)
@@ -58,5 +71,7 @@ class BondTyperLegacy:
                 bond_id in amide_bonds
                 or (bond_id[1], bond_id[0]) in amide_bonds
             ) and not flexible_amides:
+                rotatable = False
+            if bond_id in triple_bonds or bond_id in single_to_rigidify:
                 rotatable = False
             bond.rotatable = rotatable

--- a/test/json_serialization_test.py
+++ b/test/json_serialization_test.py
@@ -359,7 +359,7 @@ def test_broken_bond():
     for bond_id, bond_info in decoded_molsetup.bond_info.items():
         count_rotatable += bond_info.rotatable
         count_breakable += bond_info.breakable
-    assert count_rotatable == 10
+    assert count_rotatable == 9
     assert count_breakable == 1
 
 # endregion

--- a/test/macrocycle_test.py
+++ b/test/macrocycle_test.py
@@ -113,7 +113,7 @@ def test_untyped_macrocycle():
     for bond_id, bond_info in molsetup_typed.bond_info.items():
         count_rotatable += bond_info.rotatable
         count_breakable += bond_info.breakable
-    assert count_rotatable == 2
+    assert count_rotatable == 1
     assert count_breakable == 0
 
     mk_prep_untyped = MoleculePreparation(untyped_macrocycles=True)
@@ -123,5 +123,5 @@ def test_untyped_macrocycle():
     for bond_id, bond_info in molsetup_untyped.bond_info.items():
         count_rotatable += bond_info.rotatable
         count_breakable += bond_info.breakable
-    assert count_rotatable == 10
+    assert count_rotatable == 9
     assert count_breakable == 1


### PR DESCRIPTION
Fixes #127 

Triple bonds are rigid.

Single bonds in nitriles are also rigid.

Implemented @rwxayheee idea of, in single-triple-single bond systems, rigidifying the single bonds and rotating the triple bond instead, as this is the most efficient approach.