### PR TITLE
add icode to BEGIN_RES

### DIFF
--- a/meeko/writer.py
+++ b/meeko/writer.py
@@ -552,7 +552,7 @@ class PDBQTWriterLegacy:
                             this_flex_pdbqt,
                             resname,
                             chain,
-                            int(resnum),
+                            str(resnum) + icode,
                             skip_rename_ca_cb=True,
                             atom_count=flex_atom_count,
                         )


### PR DESCRIPTION
Fixes #201. Tested with Vina: with a flexible sidechain that has an icode:
```
mk_prepare_receptor.py -i test/polymer_data/1igy_B_82-83_has-icode.pdb -o receptor -f B:82A -p -j
```
And tested the export code path that creates PDB with docked flexible sidechain positions:
```
mk_export.py vina_docked.pdbqt -j receptor.json -s ligand_docked.sdf -p protein_docked.pdb
```
@rwxayheee could you do the same with AD-GPU?