### PR TITLE
Fix bond canonicalization bug in BondTyperLegacy for terminal triple bonds

### DIFF
--- a/meeko/bondtyper.py
+++ b/meeko/bondtyper.py
@@ -40,11 +40,12 @@ class BondTyperLegacy:
         single_triple_single = [
             (x[0], x[1], x[2], x[3]) for x in setup.find_pattern("[*]-[*]#[*]-[*]")
         ]
+        canonicalize_bond = lambda i, j: (i, j) if i < j else (j, i)
         single_to_rigidify = []
         for i, j, k, m in single_triple_single:
-            triple_bonds.remove((j, k))
-            single_to_rigidify.append((i, j))
-            single_to_rigidify.append((k, m))
+            triple_bonds.remove(canonicalize_bond(j, k))
+            single_to_rigidify.append(canonicalize_bond(i, j))
+            single_to_rigidify.append(canonicalize_bond(k, m))
         # fully rigidify nitrile and alike
         single_to_rigidify.extend(
             [(x[0], x[1]) for x in setup.find_pattern("[*]-[*]#[*X1]")]

--- a/meeko/bondtyper.py
+++ b/meeko/bondtyper.py
@@ -18,8 +18,9 @@ class BondTyperLegacy:
             rigidify_bond_smarts (list): patterns to freeze bonds, e.g. conjugated carbons
         """
 
+        canonicalize_bond = lambda i, j: (i, j) if i < j else (j, i)  # same as Bond.get_bond_id
         amide_bonds = [
-            (x[0], x[1]) for x in setup.find_pattern("[NX3]-[CX3]=[O,N,S]")
+            canonicalize_bond(x[0], x[1]) for x in setup.find_pattern("[NX3]-[CX3]=[O,N,S]")
         ]  # includes amidines
 
         # tertiary amides with non-identical substituents will be allowed to rotate
@@ -32,15 +33,14 @@ class BondTyperLegacy:
         for x in tertiary_amides:
             r1, r2 = x[1], x[2]
             if equivalent_atoms[r1] != equivalent_atoms[r2]:
-                amide_bonds.remove((x[0], x[3]))
+                amide_bonds.remove(canonicalize_bond(x[0], x[3]))
                 num_amides_removed += 1
         assert num_amides_originally == num_amides_removed + len(amide_bonds)
 
-        triple_bonds = [(x[0], x[1]) for x in setup.find_pattern("[*]#[*]")]
+        triple_bonds = [canonicalize_bond(x[0], x[1]) for x in setup.find_pattern("[*]#[*]")]
         single_triple_single = [
             (x[0], x[1], x[2], x[3]) for x in setup.find_pattern("[*]-[*]#[*]-[*]")
         ]
-        canonicalize_bond = lambda i, j: (i, j) if i < j else (j, i)
         single_to_rigidify = []
         for i, j, k, m in single_triple_single:
             triple_bonds.remove(canonicalize_bond(j, k))
@@ -48,7 +48,7 @@ class BondTyperLegacy:
             single_to_rigidify.append(canonicalize_bond(k, m))
         # fully rigidify nitrile and alike
         single_to_rigidify.extend(
-            [(x[0], x[1]) for x in setup.find_pattern("[*]-[*]#[*X1]")]
+            [canonicalize_bond(x[0], x[1]) for x in setup.find_pattern("[*]-[*]#[*X1]")]
         )
         to_rigidify = set()
         n_smarts = len(rigidify_bonds_smarts)
@@ -60,18 +60,14 @@ class BondTyperLegacy:
             for indices in indices_list:
                 atom_a = indices[a]
                 atom_b = indices[b]
-                to_rigidify.add((atom_a, atom_b))
-                to_rigidify.add((atom_b, atom_a))
+                to_rigidify.add(canonicalize_bond(atom_a, atom_b))
 
         for bond_id, bond in setup.bond_info.items():
             rotatable = True
             if bond_id in to_rigidify:
                 rotatable = False
             # check if bond is amide
-            if (
-                bond_id in amide_bonds
-                or (bond_id[1], bond_id[0]) in amide_bonds
-            ) and not flexible_amides:
+            if bond_id in amide_bonds and not flexible_amides:
                 rotatable = False
             if bond_id in triple_bonds or bond_id in single_to_rigidify:
                 rotatable = False


### PR DESCRIPTION
Fixes #364

## Solution
Applied proper bond canonicalization in the `single_triple_single` processing loop:

```python
canonicalize_bond = lambda i, j: (i, j) if i < j else (j, i)
for i, j, k, m in single_triple_single:
    triple_bonds.remove(canonicalize_bond(j, k))  # Fixed: Bond canonicalized
    single_to_rigidify.append(canonicalize_bond(i, j))
    single_to_rigidify.append(canonicalize_bond(k, m))
```

The issue was that `triple_bonds` stores bonds in canonical form `(i, j)` where `i < j`, but the code was trying to remove `(j, k)` which might be in reverse order.

## Testing
✅ Verified the fix with the reproduction case from #364 - ligand preparation now completes successfully.

## Note
This fix resolves the specific case identified in #364, but I'm not entirely sure if this canonicalization approach will handle all edge cases with triple bonds. I'm open to feedback and suggestions for a more robust solution if needed.