### PR TITLE
support altloc B in PDB for mk_prepare_receptor.py --box_enveloping

### DIFF
--- a/meeko/cli/mk_prepare_receptor.py
+++ b/meeko/cli/mk_prepare_receptor.py
@@ -838,7 +838,6 @@ def main():
                 ligmol = Chem.MolFromPDBBlock(pdbstr, removeHs=False, sanitize=False)
             elif ft != ".sdf" and ft != ".pdbqt":
                 ligmol = suppliers[ft](args.box_enveloping, removeHs=False, sanitize=False)
-                Chem.MolToMolFile(ligmol, "ligmol.mol")
             elif ft == ".sdf":
                 ligmol = suppliers[ft](args.box_enveloping, removeHs=False, sanitize=False)[
                     0

--- a/meeko/cli/mk_prepare_receptor.py
+++ b/meeko/cli/mk_prepare_receptor.py
@@ -21,6 +21,7 @@ from meeko import PolymerCreationError
 from meeko import reactive_typer
 from meeko import get_reactive_config
 from meeko import gridbox
+from meeko import pdbutils
 from meeko import __file__ as pkg_init_path
 from rdkit import Chem
 
@@ -821,7 +822,7 @@ def main():
         elif args.box_enveloping is not None:
             ft = pathlib.Path(args.box_enveloping).suffix
             suppliers = {
-                ".pdb": Chem.MolFromPDBFile,
+                ".pdb": None,  # overriden below, needed here as valid type
                 ".mol": Chem.MolFromMolFile,
                 ".mol2": Chem.MolFromMol2File,
                 ".sdf": Chem.SDMolSupplier,
@@ -832,8 +833,12 @@ def main():
                     success=False,
                     error_msg=f"Given --box_enveloping file type {ft} not readable!"
                 )
+            elif ft == ".pdb":
+                pdbstr = pdbutils.strip_altloc_from_pdb_file(args.box_enveloping)
+                ligmol = Chem.MolFromPDBBlock(pdbstr, removeHs=False, sanitize=False)
             elif ft != ".sdf" and ft != ".pdbqt":
                 ligmol = suppliers[ft](args.box_enveloping, removeHs=False, sanitize=False)
+                Chem.MolToMolFile(ligmol, "ligmol.mol")
             elif ft == ".sdf":
                 ligmol = suppliers[ft](args.box_enveloping, removeHs=False, sanitize=False)[
                     0

--- a/meeko/utils/pdbutils.py
+++ b/meeko/utils/pdbutils.py
@@ -3,3 +3,18 @@ from collections import namedtuple
 # named tuple to contain information about an atom
 PDBAtomInfo = namedtuple("PDBAtomInfo", "name resName resNum icode chain")
 PDBResInfo = namedtuple("PDBResInfo", "resName resNum chain")  # used in obutils, maybe
+
+def strip_altloc_from_pdb_file(filename):
+    """this is a hack to pass a PDB string to RDKit's PDB parser because
+    it ignores atoms for which altloc isn't either "A" or " ", but we
+    may want to pass a file with "B" altlocs to the --box_enveloping
+    argument of mk_prepare_receptor.py"""
+
+    pdbstr = ""
+    with open(filename) as f:
+        for line in f:
+            if line.startswith("ATOM") or line.startswith("HETATM"):
+                pdbstr += line[:16] + " " + line[17:]
+            else:
+                pdbstr += line
+    return pdbstr


### PR DESCRIPTION
The RDKit PDB parser ignores atoms with altloc "B" (or any altloc that isn't either "A" or empty " "). This PR pre-processes the PDB string to set the altloc of all atoms to an empty string. This is exclusively for PDB files passed to `mk_prepare_receptor.py --box_enveloping` argument.