### PR TITLE
assign espaloma charges to single atom molecules

### DIFF
--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -19,7 +19,6 @@ from typing import Optional, Any
 import numpy as np
 import rdkit.Chem
 from rdkit import Chem
-from rdkit.Chem import rdPartialCharges
 from rdkit.Chem import rdMolInterchange
 
 from .utils.jsonutils import rdkit_mol_from_json, tuple_to_string, string_to_tuple
@@ -30,7 +29,6 @@ from .utils import rdkitutils
 from .utils import utils
 from .utils.geomutils import calcDihedral
 from .utils.pdbutils import PDBAtomInfo
-from .receptor_pdbqt import PDBQTReceptor
 
 try:
     from misctools import StereoIsomorphism
@@ -1617,34 +1615,6 @@ class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolkit, BaseJSONPa
 
         return molsetup
 
-    @staticmethod
-    def remove_elements(mol, to_rm=(12, 20, 25, 26, 30)):
-        idx_to_rm = {}
-        neigh_idx_to_nr_h = {}
-        rm_to_neigh = {}
-        for atom in mol.GetAtoms():
-            if atom.GetAtomicNum() in to_rm:
-                idx_to_rm[atom.GetIdx()] = atom.GetFormalCharge()
-                rm_to_neigh[atom.GetIdx()] = set()
-                for neigh in atom.GetNeighbors():
-                    n = neigh.GetNumExplicitHs()
-                    neigh_idx_to_nr_h[neigh.GetIdx()] = n
-                    rm_to_neigh[atom.GetIdx()].add(neigh.GetIdx())
-        if not idx_to_rm:
-            return Chem.Mol(mol), idx_to_rm, rm_to_neigh
-        rwmol = Chem.EditableMol(mol)
-        for idx in sorted(idx_to_rm, reverse=True):
-            rwmol.RemoveAtom(idx)
-        mol = rwmol.GetMol()
-        for idx in neigh_idx_to_nr_h:
-            n = neigh_idx_to_nr_h[idx]
-            newidx = idx - sum([i < idx for i in idx_to_rm]) 
-            mol.GetAtomWithIdx(newidx).SetNumExplicitHs(n + 1)
-        mol.UpdatePropertyCache()
-        Chem.SanitizeMol(mol)
-        mol = Chem.AddHs(mol)
-        return mol, idx_to_rm, rm_to_neigh
-
     def init_atom(self, compute_gasteiger_charges: bool, read_charges_from_prop: str, coords: list[np.ndarray]):
         """
         Generates information about the atoms in an RDKit Mol and adds them to an RDKitMoleculeSetup.
@@ -1666,46 +1636,7 @@ class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolkit, BaseJSONPa
                 raise ValueError(
                     "Conflicting options: compute_gasteiger_charges and read_charges_from_prop cannot both be set. "
                 )
-            things = self.remove_elements(self.mol)
-            copy_mol, idx_rm_to_formal_charge, rm_to_neigh = things
-            for atom in copy_mol.GetAtoms():
-                if atom.GetAtomicNum() == 34:
-                    atom.SetAtomicNum(16)
-            rdPartialCharges.ComputeGasteigerCharges(copy_mol)
-            charges = [a.GetDoubleProp("_GasteigerCharge") for a in copy_mol.GetAtoms()]
-            if idx_rm_to_formal_charge:
-                ok_charges = charges.copy()
-                for i in sorted(idx_rm_to_formal_charge, reverse=True):
-                    ok_charges.insert(i, 0.0)
-                nr_rm = len(idx_rm_to_formal_charge)
-                nr_added_h = copy_mol.GetNumAtoms() - self.mol.GetNumAtoms() + nr_rm
-                ok_charges = ok_charges[:len(ok_charges)-nr_added_h]
-                # print(f"{nr_added_h=}")
-                # print(f"{nr_rm=}")
-                # print(f"{idx_rm_to_formal_charge=}")
-                # print(f"{len(charges)=}")
-                # print(f"{len(ok_charges)=}")
-                # print(f"{copy_mol.GetNumAtoms()=}")
-                # print(f"{self.mol.GetNumAtoms()=}")
-                chrg_by_heavy_atom = {}
-                for i in range(nr_added_h):
-                    added_H_idx = self.mol.GetNumAtoms() + i - nr_rm
-                    # print(f"{added_H_idx=}")
-                    neighs = copy_mol.GetAtomWithIdx(added_H_idx).GetNeighbors()
-                    if len(neighs) != 1:
-                        raise RuntimeError("H should have 1 neighbor")
-                    if neighs[0].GetIdx() in chrg_by_heavy_atom:
-                        raise RuntimeError("expected only 1 added H per heavy atom, maybe deleted element had double bond to this heavy atom")
-                    chrg_by_heavy_atom[neighs[0].GetIdx()] = charges[added_H_idx]
-                # print(f"{chrg_by_heavy_atom=}")
-                for i, neighs in rm_to_neigh.items():
-                    # print(f"{i=}, {neighs=}")
-                    ok_charges[i] += idx_rm_to_formal_charge[i]
-                    for idx in neighs:
-                        newidx = idx - sum([i <= idx for i in idx_rm_to_formal_charge]) 
-                        # print(f"{idx=} {newidx=}")
-                        ok_charges[i] += chrg_by_heavy_atom[newidx]
-                charges = ok_charges
+            charges = rdkitutils.compute_gasteiger_charges(self.mol)
         elif read_charges_from_prop is not None: 
             if not isinstance(read_charges_from_prop, str) or not read_charges_from_prop: 
                 raise ValueError(

--- a/meeko/polymer.py
+++ b/meeko/polymer.py
@@ -26,7 +26,6 @@ from .utils.jsonutils import convert_to_int_keyed_dict
 from .utils.rdkitutils import mini_periodic_table
 from .utils.rdkitutils import react_and_map
 from .utils.rdkitutils import AtomField
-from .utils.rdkitutils import build_one_rdkit_mol_per_altloc
 from .utils.rdkitutils import _aux_altloc_mol_build
 from .utils.rdkitutils import covalent_radius
 from .utils.pdbutils import PDBAtomInfo

--- a/meeko/preparation.py
+++ b/meeko/preparation.py
@@ -540,15 +540,20 @@ class MoleculePreparation:
 
         # Convert molecule to graph and apply trained Espaloma model
         if self.dihedral_model == "espaloma" or self.charge_model == "espaloma":
-            molgraph = self.espaloma_model.get_espaloma_graph(setup)
+            if mol.GetNumAtoms() > 1:
+                molgraph = self.espaloma_model.get_espaloma_graph(setup)
 
         # Grab dihedrals from graph node and set them to the molsetup
-        if self.dihedral_model == "espaloma":
+        if self.dihedral_model == "espaloma" and mol.GetNumAtoms() > 3:
             self.espaloma_model.set_espaloma_dihedrals(setup, molgraph)
 
         # Grab charges from graph node and set them to the molsetup
         if self.charge_model == "espaloma":
-            self.espaloma_model.set_espaloma_charges(setup, molgraph)
+            if mol.GetNumAtoms() > 1:
+                self.espaloma_model.set_espaloma_charges(setup, molgraph)
+            else:
+                setup.atoms[0].charge = float(mol.GetAtomWithIdx(0).GetFormalCharge())
+
 
         # merge hydrogens (or any terminal atoms)
         indices = set()

--- a/meeko/utils/rdkitutils.py
+++ b/meeko/utils/rdkitutils.py
@@ -4,6 +4,7 @@ from .utils import mini_periodic_table
 from .pdbutils import PDBAtomInfo
 from rdkit.Geometry import Point3D
 from rdkit.Chem import rdDetermineBonds
+from rdkit.Chem import rdPartialCharges
 
 periodic_table = Chem.GetPeriodicTable()
 
@@ -458,6 +459,68 @@ def react_and_map(reactants: tuple[Chem.Mol], rxn: rdChemReactions.ChemicalReact
 
     return outcomes
 
+def remove_elements(mol, to_rm=(12, 20, 25, 26, 30)):
+    idx_to_rm = {}
+    neigh_idx_to_nr_h = {}
+    rm_to_neigh = {}
+    for atom in mol.GetAtoms():
+        if atom.GetAtomicNum() in to_rm:
+            idx_to_rm[atom.GetIdx()] = atom.GetFormalCharge()
+            rm_to_neigh[atom.GetIdx()] = set()
+            for neigh in atom.GetNeighbors():
+                n = neigh.GetNumExplicitHs()
+                neigh_idx_to_nr_h[neigh.GetIdx()] = n
+                rm_to_neigh[atom.GetIdx()].add(neigh.GetIdx())
+    if not idx_to_rm:
+        return Chem.Mol(mol), idx_to_rm, rm_to_neigh
+    rwmol = Chem.EditableMol(mol)
+    for idx in sorted(idx_to_rm, reverse=True):
+        rwmol.RemoveAtom(idx)
+    mol = rwmol.GetMol()
+    for idx in neigh_idx_to_nr_h:
+        n = neigh_idx_to_nr_h[idx]
+        newidx = idx - sum([i < idx for i in idx_to_rm]) 
+        mol.GetAtomWithIdx(newidx).SetNumExplicitHs(n + 1)
+    mol.UpdatePropertyCache()
+    Chem.SanitizeMol(mol)
+    mol = Chem.AddHs(mol)
+    return mol, idx_to_rm, rm_to_neigh
+
+def compute_gasteiger_charges(rdkit_mol):
+    things = remove_elements(rdkit_mol)
+    copy_mol, idx_rm_to_formal_charge, rm_to_neigh = things
+    for atom in copy_mol.GetAtoms():
+        if atom.GetAtomicNum() == 34:
+            atom.SetAtomicNum(16)
+    rdPartialCharges.ComputeGasteigerCharges(copy_mol)
+    charges = [a.GetDoubleProp("_GasteigerCharge") for a in copy_mol.GetAtoms()]
+    if idx_rm_to_formal_charge:
+        ok_charges = charges.copy()
+        for i in sorted(idx_rm_to_formal_charge, reverse=True):
+            ok_charges.insert(i, 0.0)
+        nr_rm = len(idx_rm_to_formal_charge)
+        nr_added_h = copy_mol.GetNumAtoms() - self.mol.GetNumAtoms() + nr_rm
+        ok_charges = ok_charges[:len(ok_charges)-nr_added_h]
+        chrg_by_heavy_atom = {}
+        for i in range(nr_added_h):
+            added_H_idx = self.mol.GetNumAtoms() + i - nr_rm
+            # print(f"{added_H_idx=}")
+            neighs = copy_mol.GetAtomWithIdx(added_H_idx).GetNeighbors()
+            if len(neighs) != 1:
+                raise RuntimeError("H should have 1 neighbor")
+            if neighs[0].GetIdx() in chrg_by_heavy_atom:
+                raise RuntimeError("expected only 1 added H per heavy atom, maybe deleted element had double bond to this heavy atom")
+            chrg_by_heavy_atom[neighs[0].GetIdx()] = charges[added_H_idx]
+        # print(f"{chrg_by_heavy_atom=}")
+        for i, neighs in rm_to_neigh.items():
+            # print(f"{i=}, {neighs=}")
+            ok_charges[i] += idx_rm_to_formal_charge[i]
+            for idx in neighs:
+                newidx = idx - sum([i <= idx for i in idx_rm_to_formal_charge]) 
+                # print(f"{idx=} {newidx=}")
+                ok_charges[i] += chrg_by_heavy_atom[newidx]
+        charges = ok_charges
+    return charges
 
 covalent_radius = {  # from wikipedia
     1: 0.31,
@@ -466,6 +529,7 @@ covalent_radius = {  # from wikipedia
     7: 0.71,
     8: 0.66,
     9: 0.57,
+    11: 0.00,  # hack to avoid bonds with salt
     12: 0.00,  # hack to avoid bonds with metals
     14: 1.11,
     15: 1.07,


### PR DESCRIPTION
Assigning charges to ions caused trouble because it's impossible to create an espaloma graph with just one atom. The error was thrown by espaloma. In this PR, if the molecule has one atom, its espaloma charge will be the formal charge.

Also moved two methods specific to Gasteiger charges from `RDKitMoleculeSetup` to `rdkitutils.py`.