### PR TITLE
Allow python 3.12, bumping version to 0.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def find_files(directory):
 
 setup(
     name="meeko",
-    version='0.6.1',
+    version='0.7.0',
     author="Forli Lab",
     author_email="forli@scripps.edu",
     url="https://github.com/ccsb-scripps/meeko",
@@ -32,7 +32,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=['numpy>=1.18', "rdkit", "scipy", "gemmi"],
-    python_requires='>=3.9, <3.12',
+    python_requires='>=3.9, <3.13',
     license="LGPL-2.1",
     keywords=["molecular modeling", "drug design",
             "docking", "autodock"],


### PR DESCRIPTION
I ran tests with python 3.12 and everything was successful.

```
================================= test session starts ==================================
platform darwin -- Python 3.12.12, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/patrickriley/coding/Meeko
plugins: unidep-1.0.1
collected 71 items                                                                     

test/cyclopentane_rigid_test.py .                                                [  1%]
test/flexibility_test.py .....                                                   [  8%]
test/flexres_export_test.py ..                                                   [ 11%]
test/json_serialization_test.py .......                                          [ 21%]
test/macrocycle_test.py ..                                                       [ 23%]
test/merge_custom_types_test.py ...                                              [ 28%]
test/molsetup_test.py ....                                                       [ 33%]
test/polymer_creation_test.py .................                                  [ 57%]
test/rdkitmol_from_docking_test.py ...........................                   [ 95%]
test/ring_detection_test.py .                                                    [ 97%]
test/skip_bad_mols_test.py ..                                                    [100%]

=================================== warnings summary ===================================
test/macrocycle_test.py::test_all
  /Users/patrickriley/coding/Meeko/meeko/molsetup.py:1599: UserWarning: RDKit molecule not labeled as 3D. This warning won't show again.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================ 71 passed, 1 warning in 8.35s =============================

```