### PR TITLE
fix: do not uniquify SMARTS matches by default (for OpenFF compat)

### DIFF
--- a/meeko/atomtyper.py
+++ b/meeko/atomtyper.py
@@ -99,7 +99,7 @@ class AtomTyper:
             for line in offatom_params[smartsgroup]:
                 # SMARTS
                 smarts = str(line["smarts"])
-                hits = molsetup.find_pattern(smarts)
+                hits = molsetup.find_pattern(smarts, uniquify=True)  # NOTE uniquifying
                 # atom indexes in smarts string
                 smarts_idxs = [0]
                 if "IDX" in line:

--- a/meeko/bondtyper.py
+++ b/meeko/bondtyper.py
@@ -27,7 +27,7 @@ class BondTyperLegacy:
 
         # tertiary amides with non-identical substituents will be allowed to rotate
         tertiary_amides = [
-            x for x in setup.find_pattern("[NX3]([!#1])([!#1])-[CX3]=[O,N,S]")
+            x for x in setup.find_pattern("[NX3]([!#1])([!#1])-[CX3]=[O,N,S]", uniquify=True)
         ]
         equivalent_atoms = setup.get_equivalent_atoms()
         num_amides_removed = 0

--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -1727,7 +1727,7 @@ class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolkit, BaseJSONPa
             rotatable = int(b.GetBondType()) == 1
             self.add_bond(idx1, idx2, rotatable=rotatable)
 
-    def find_pattern(self, smarts: str):
+    def find_pattern(self, smarts: str, uniquify=False, max_matches=int(1e7)):
         """
         Given a SMARTS pattern, finds substruct matches in the molecule.
 
@@ -1741,8 +1741,14 @@ class RDKitMoleculeSetup(MoleculeSetup, MoleculeSetupExternalToolkit, BaseJSONPa
         The substruct matches in the RDKit Mol for the given SMARTS.
         """
         p = Chem.MolFromSmarts(smarts)
-        nr_atoms = self.mol.GetNumAtoms()
-        return self.mol.GetSubstructMatches(p, maxMatches=nr_atoms)
+        # the default maxMatches is 1000, which is insufficient for very large molecules
+        # a very flexible smarts "[*]~[*]~[*](~[*])~[*]~[*]" produced 2.1 M matches
+        # with a molecule (protein) consisting of 10k arginines. The default herein
+        # is very generous at 10 M
+        # OpenFF uses uniquify=False. If we don't do that we parameterize only one of
+        # the water H with TIP3P parameters from OpenFF XML files (the other H gets
+        # general hydroxyl parameters)
+        return self.mol.GetSubstructMatches(p, uniquify=uniquify, maxMatches=max_matches)
 
     def get_mol_name(self):
         """

--- a/test/parameterization_test.py
+++ b/test/parameterization_test.py
@@ -56,6 +56,20 @@ def test_dihedral_indexing():
     assert a_nr == b_nr
     return
 
+@pytest.mark.skipif(not _got_openff, reason="requires openff-forcefields")
+def test_openff_water():
+    etkdg_v3 = Chem.rdDistGeom.ETKDGv3()
+    water = Chem.MolFromSmiles("O")
+    water = Chem.AddHs(water)
+    Chem.rdDistGeom.EmbedMolecule(water, etkdg_v3)
+    mk_prep = MoleculePreparation(load_atom_params=["openff"]) 
+    molsetup = mk_prep(water)[0]
+    rmin_half = molsetup.atom_params["rmin_half"]
+    epsilon = molsetup.atom_params["epsilon"]
+    assert rmin_half[1] == rmin_half[2] 
+    assert epsilon[1] == epsilon[2] 
+    return
+
 def test_merge_rmin_half():
     methanol = Chem.AddHs(Chem.MolFromSmiles("CO"))
     etkdg_v3 = rdDistGeom.ETKDGv3()


### PR DESCRIPTION
The bug was discovered by inspecting water parameters, each hydrogen had different parameters. One H had TIP3P parameters, while the other had hydroxyl parameters. This happened because the OpenFF XML forcefield file specifies both hydrogens in the SMARTS, for example `[H:1]O[H]` but only the one with the ":1" label is parameterized. With `uniquify=True` (RDKit's default, in use before this PR) only one match is returned. By setting `uniquify=False`, RDKit returns two matches instead of one, in which each match labels a different H.