### PR TITLE
Feat: Add option to ignore https certificate for PDB download

### DIFF
--- a/meeko/chemtempgen.py
+++ b/meeko/chemtempgen.py
@@ -850,7 +850,7 @@ def export_chem_templates_to_json(cc_list: list[ChemicalComponent], json_fname: 
         return json_str
 
 
-def fetch_from_pdb(resname: str, max_retries = 5, backoff_factor = 2) -> str: 
+def fetch_from_pdb(resname: str, max_retries = 5, backoff_factor = 2, ignore_https_cert = False) -> str: 
     """
     Fetch a CIF file from the RCSB PDB website for a given residue name.
 
@@ -875,6 +875,10 @@ def fetch_from_pdb(resname: str, max_retries = 5, backoff_factor = 2) -> str:
     """
     url = f"https://files.rcsb.org/ligands/download/{resname}.cif"
     file_path = f"{resname}.cif"
+    print(f"{ignore_https_cert}")
+    if ignore_https_cert:
+        import ssl
+        ssl._create_default_https_context = ssl._create_unverified_context
     for retry in range(max_retries):
         try:
             with urllib.request.urlopen(url) as response:
@@ -897,7 +901,7 @@ def fetch_from_pdb(resname: str, max_retries = 5, backoff_factor = 2) -> str:
                 logger.info(f"Download failed for {resname}. Error: {e}. Retrying in {wait_time} seconds...")
                 time.sleep(wait_time)
             else:
-                err = f"Max retries reached. Could not download CIF file for {resname}. Error: {e}"
+                err = f"Max retries reached. Could not download CIF file for {resname}. If this is a certificate error and you trust rcsb.org is not spoofed, you could try the --ignore_https_cert option. Error: {e}"
                 raise RuntimeError(err) from e
 
 # Default chemical groups for deprotonate
@@ -912,7 +916,7 @@ acidic_proton_loc_canonical = {
     }
 
 # Standard pipelines
-def build_noncovalent_CC(basename: str) -> ChemicalComponent: 
+def build_noncovalent_CC(basename: str, ignore_https_cert = False) -> ChemicalComponent: 
     """
     Build a noncovalent chemical component from a CIF file.
 
@@ -927,7 +931,7 @@ def build_noncovalent_CC(basename: str) -> ChemicalComponent:
         The constructed ChemicalComponent instance.
     """
     with ChemicalComponent_LoggingControler(): 
-        cc_from_cif = ChemicalComponent.from_cif(fetch_from_pdb(basename), basename)
+        cc_from_cif = ChemicalComponent.from_cif(fetch_from_pdb(basename, ignore_https_cert=ignore_https_cert), basename)
         if cc_from_cif is None:
             return None
 
@@ -1057,7 +1061,7 @@ class NA_recipe:
 def build_linked_CCs(basename: str, embed_allowed_smarts: str = None, 
                      cap_allowed_smarts: str = None, cap_protonate: bool = False, 
                      pattern_to_label_mapping_standard = dict[str, str], 
-                     variant_dict = dict[str, tuple]) -> list[ChemicalComponent]: 
+                     variant_dict = dict[str, tuple], ignore_https_cert = False) -> list[ChemicalComponent]: 
     """
     Build a linked chemical component from a CIF file.
 
@@ -1084,7 +1088,7 @@ def build_linked_CCs(basename: str, embed_allowed_smarts: str = None,
         List of ChemicalComponent instances with the added variants.
     """
     with ChemicalComponent_LoggingControler(): 
-        cc_from_cif = ChemicalComponent.from_cif(fetch_from_pdb(basename), basename)
+        cc_from_cif = ChemicalComponent.from_cif(fetch_from_pdb(basename, ignore_https_cert=ignore_https_cert), basename)
         if cc_from_cif is None:
             return None
         

--- a/meeko/chemtempgen.py
+++ b/meeko/chemtempgen.py
@@ -875,8 +875,8 @@ def fetch_from_pdb(resname: str, max_retries = 5, backoff_factor = 2, ignore_htt
     """
     url = f"https://files.rcsb.org/ligands/download/{resname}.cif"
     file_path = f"{resname}.cif"
-    print(f"{ignore_https_cert}")
     if ignore_https_cert:
+        logger.warning(f"Ignoring https certificate of {url}.")
         import ssl
         ssl._create_default_https_context = ssl._create_unverified_context
     for retry in range(max_retries):

--- a/meeko/cli/mk_prepare_receptor.py
+++ b/meeko/cli/mk_prepare_receptor.py
@@ -133,6 +133,11 @@ def get_args():
         metavar="PDB_FILENAME",
     )
     io_group.add_argument(
+        "--ignore_https_cert",
+        action="store_true",
+        help="Ignore https certificate errors when downloading from PDB database (potentially dangerous if rscb.org were spoofed, please only use as a last resort) ",
+    )
+    io_group.add_argument(
         "-g",
         "--write_gpf",
         metavar="GPF_FILENAME",
@@ -569,6 +574,7 @@ def main():
                     mk_prep,
                     set_template,
                     delete_residues,
+                    args.ignore_https_cert,
                     args.allow_bad_res,
                     blunt_ends=blunt_ends,
                     wanted_altloc=wanted_altloc,
@@ -587,6 +593,7 @@ def main():
                 mk_prep,
                 set_template,
                 delete_residues,
+                args.ignore_https_cert,
                 args.allow_bad_res,
                 blunt_ends=blunt_ends,
                 wanted_altloc=wanted_altloc,
@@ -615,6 +622,7 @@ def main():
                 mk_prep,
                 set_template,
                 delete_residues,
+                args.ignore_https_cert,
                 args.allow_bad_res,
                 blunt_ends=blunt_ends,
             )

--- a/meeko/polymer.py
+++ b/meeko/polymer.py
@@ -763,6 +763,7 @@ class Polymer(BaseJSONParsable):
         set_template: dict[str, str] = None,
         blunt_ends: list[tuple[str, int]] = None,
         get_atomprop_from_raw: dict = None,
+        ignore_https_cert = False,
     ):
         """
         Parameters
@@ -870,7 +871,7 @@ class Polymer(BaseJSONParsable):
             if unbound_unknown_res: 
                 for resname in set(unbound_unknown_res.values()): 
                     try: 
-                        cc = build_noncovalent_CC(resname)
+                        cc = build_noncovalent_CC(resname, ignore_https_cert=ignore_https_cert)
                         fetch_template_dict = json.loads(export_chem_templates_to_json([cc]))['residue_templates'][cc.resname]
                         residue_templates.update({resname: ResidueTemplate(
                                                     smiles = fetch_template_dict['smiles'],
@@ -885,7 +886,7 @@ class Polymer(BaseJSONParsable):
                 failed_build = set()
                 try: 
                     for resname in set(bonded_unknown_res.values()): 
-                        cc_list = build_linked_CCs(resname)
+                        cc_list = build_linked_CCs(resname, ignore_https_cert=ignore_https_cert)
                         if not cc_list: 
                             failed_build.add(resname)
                         else:
@@ -1073,6 +1074,7 @@ class Polymer(BaseJSONParsable):
         mk_prep,
         set_template=None,
         residues_to_delete=None,
+        ignore_https_cert=False,
         allow_bad_res=False,
         bonds_to_delete=None,
         blunt_ends=None,
@@ -1088,6 +1090,7 @@ class Polymer(BaseJSONParsable):
         mk_prep
         set_template
         residues_to_delete
+        ignore_https_cert
         allow_bad_res
         bonds_to_delete
         blunt_ends
@@ -1166,6 +1169,7 @@ class Polymer(BaseJSONParsable):
         mk_prep,
         set_template=None,
         residues_to_delete=None,
+        ignore_https_cert=False,
         allow_bad_res=False,
         bonds_to_delete=None,
         blunt_ends=None,
@@ -1179,6 +1183,7 @@ class Polymer(BaseJSONParsable):
         mk_prep
         set_template
         residues_to_delete
+        ignore_https_cert
         allow_bad_res
         bonds_to_delete
         blunt_ends
@@ -1264,6 +1269,7 @@ class Polymer(BaseJSONParsable):
         mk_prep,
         set_template=None,
         residues_to_delete=None,
+        ignore_https_cert=False,
         allow_bad_res=False,
         bonds_to_delete=None,
         blunt_ends=None,
@@ -1279,6 +1285,7 @@ class Polymer(BaseJSONParsable):
         mk_prep
         set_template
         residues_to_delete
+        ignore_https_cert
         allow_bad_res
         bonds_to_delete
         blunt_ends

--- a/meeko/polymer.py
+++ b/meeko/polymer.py
@@ -782,6 +782,7 @@ class Polymer(BaseJSONParsable):
             A dict mapping residue IDs in the format <chain>:<resnum> such as "A:42" to ResidueTemplate instances.
         blunt_ends: list (tuple (string, int))
             A list of tuples where each tuple is residue IDs and 0-based atom index, e.g.; ("A:42", 0)
+        ignore_https_cert: Ignore https cert of PDB database (rcsb.org) when True
 
         Returns
         -------
@@ -1147,6 +1148,8 @@ class Polymer(BaseJSONParsable):
             mk_prep,
             set_template,
             blunt_ends,
+            None,
+            ignore_https_cert
         )
 
         unmatched_res = polymer.get_ignored_monomers()
@@ -1238,6 +1241,7 @@ class Polymer(BaseJSONParsable):
             set_template,
             blunt_ends,
             get_atomprop_from_raw = {"PQRCharge": 0.},
+            ignore_https_cert=ignore_https_cert
         )
 
         if polymer.log["matched_with_H_anomaly"]:
@@ -1343,6 +1347,8 @@ class Polymer(BaseJSONParsable):
             mk_prep,
             set_template,
             blunt_ends,
+            None,
+            ignore_https_cert
         )
         unmatched_res = polymer.get_ignored_monomers()
         handle_parsing_situations(


### PR DESCRIPTION
Analogous to the option `--no-check-certificate` in wget, this PR adds the option `--ignore_https_cert` (default is False) to bypass https certificate checks for downloads from the PDB database as a last resort in systems with either misconfigured certificate providers or website misconfiguration.

This is a somewhat dangerous thing to do as spoofing of rcsb.org would not be detected, thus plenty of warning notes are included.