### PR TITLE
feat: speed up (and rename) polymer.stitch function.

### DIFF
--- a/meeko/polymer.py
+++ b/meeko/polymer.py
@@ -193,7 +193,7 @@ def find_inter_mols_bonds(mols_dict,
     tree = cKDTree(xyz)
 
     # candidate atom pairs within max cutoff
-    # narrow down
+    # narrow down search
     # returns set of (i, j) with i < j
     cand = np.array(list(tree.query_pairs(r=max_possible_covalent_radius)), dtype=np.int64)
     if cand.size == 0:
@@ -1144,6 +1144,9 @@ class Polymer(BaseJSONParsable):
         padders = residue_chem_templates.padders
         ambiguous = residue_chem_templates.ambiguous
 
+        # store a copy of bonds.
+        self.bonds = bonds.copy()
+
         if set_template is None:
             set_template = {}
         else:  # make sure all resiude_id in set_template exist
@@ -1301,10 +1304,34 @@ class Polymer(BaseJSONParsable):
         "log",
     }
 
-    def stitch(self, residues_to_add: Optional[set[str]] = None, 
+    @classmethod
+    def _combine_many_mols_tree(cls, mols):
+        r"""tree-like compbination of mols iterable (nlog(n) cost).
+
+            mols: 
+            (a,b)   (b,c)
+              \       /
+               (ab, bc)
+                   |
+                 abcd   
+
+        """
+        mols = list(mols)
+        if not mols:
+            return Chem.Mol()
+        while len(mols) > 1:
+            nxt = []
+            it = iter(mols)
+            for a in it:
+                b = next(it, None)
+                nxt.append(Chem.CombineMols(a, b) if b is not None else a)
+            mols = nxt
+        return mols[0]
+
+    def to_rdkit_mol(self, residues_to_add: Optional[set[str]] = None, 
                bonds_to_use: Optional[dict[tuple[str], list[tuple[int]]]] = None):
         """returns a single rdkit molecule that results from adding bonds
-            between every chorizo residue. It may contain multiple fragments
+            between every monomer residue. It may contain multiple fragments
             if there are multiple chains or gaps. 
 
             Optionally, specify a set of residue IDs for stitching.
@@ -1331,7 +1358,12 @@ class Polymer(BaseJSONParsable):
         if bonds_to_use is None:
             bonds_to_use = {}
             resid_to_rawmols = {res_id: (self.monomers[res_id].raw_rdkit_mol, self.monomers[res_id].input_resname) for res_id in residues_to_add}
-            bonds_indexed_in_raw = find_inter_mols_bonds(resid_to_rawmols)
+            
+            if self.bonds is None: 
+                bonds_indexed_in_raw = find_inter_mols_bonds(resid_to_rawmols)
+            else:
+                bonds_indexed_in_raw = self.bonds
+
             invmaps = {
                 res_id: {j: i for i, j in self.monomers[res_id].mapidx_to_raw.items()}
                 for res_id in residues_to_add
@@ -1347,11 +1379,16 @@ class Polymer(BaseJSONParsable):
         
         # add residues and get offset in order
         offset = 0
+        mols = []
         for r_id in residues_to_add:
             res = self.monomers[r_id]
+            m = res.rdkit_mol
             residues_added[r_id] = offset
-            offset += res.rdkit_mol.GetNumAtoms()
-            mol = Chem.CombineMols(mol, res.rdkit_mol)
+            offset += m.GetNumAtoms()
+            # mol = Chem.CombineMols(mol, res.rdkit_mol)
+            mols.append(m)
+
+        mol = Polymer._combine_many_mols_tree(mols)
 
         # add bonds
         edit_mol = Chem.EditableMol(mol)
@@ -1369,6 +1406,7 @@ class Polymer(BaseJSONParsable):
                         order=Chem.rdchem.BondType.SINGLE
                     )
         mol = edit_mol.GetMol()
+
         
         # review added bonds and residues
         if len(bonds_spent) != len(bonds_to_use):
@@ -1377,6 +1415,12 @@ class Polymer(BaseJSONParsable):
             raise RuntimeError("nr of residues added differs from residues to add")
         
         return mol
+    
+    # for backwards compatibility. 
+    def stitch(self, residues_to_add = None, 
+               bonds_to_use = None):
+        """ Alias of polymer.to_rdkit_mol."""
+        return self.to_rdkit_mol(residues_to_add, bonds_to_use)
 
     @classmethod
     def _decode_object(cls, obj: dict[str, Any]): 
@@ -1468,14 +1512,6 @@ class Polymer(BaseJSONParsable):
 
         bonds = find_inter_mols_bonds(raw_input_mols)
 
-
-        # code for testing, leaving it for now
-        # print("testing find_inter_mols")
-        # print(len(bonds), len(bonds_old))
-        # for k,v in bonds_old.items():
-        #     print(k, bonds_old[k], bonds[k], bonds_old[k] == bonds[k])
-
-
         if bonds_to_delete is not None:
             for res1, res2 in bonds_to_delete:
                 popped = ()
@@ -1489,6 +1525,7 @@ class Polymer(BaseJSONParsable):
                         " than one bond between them"
                     )
                     raise NotImplementedError(msg)
+
         polymer = cls(
             raw_input_mols,
             bonds,

--- a/meeko/polymer.py
+++ b/meeko/polymer.py
@@ -1314,9 +1314,9 @@ class Polymer(BaseJSONParsable):
         r"""tree-like compbination of mols iterable (nlog(n) cost).
 
             mols: 
-            (a,b)   (b,c)
+            (a,b)   (c,d)
               \       /
-               (ab, bc)
+               (ab, cd)
                    |
                  abcd   
 

--- a/meeko/polymer.py
+++ b/meeko/polymer.py
@@ -1363,8 +1363,9 @@ class Polymer(BaseJSONParsable):
         if bonds_to_use is None:
             bonds_to_use = {}
             resid_to_rawmols = {res_id: (self.monomers[res_id].raw_rdkit_mol, self.monomers[res_id].input_resname) for res_id in residues_to_add}
-            
-            if self.bonds is None: 
+
+            # check if bonds is None or empty. 
+            if self.bonds is None or not self.bonds: 
                 bonds_indexed_in_raw = find_inter_mols_bonds(resid_to_rawmols)
             else:
                 bonds_indexed_in_raw = self.bonds

--- a/test/polymer_creation_test.py
+++ b/test/polymer_creation_test.py
@@ -626,7 +626,7 @@ def test_stitch_polymer():
     )
     adjacent_disulfide = Chem.MolFromSmarts("S1CCNCCCS1")
     disulfide_then_proline = Chem.MolFromSmarts("CSSCCC(=O)N1CCCC1")
-    stitched_mol = polymer.stitch()
+    stitched_mol = polymer.to_rdkit_mol()
     assert stitched_mol.HasSubstructMatch(adjacent_disulfide)
     assert stitched_mol.HasSubstructMatch(disulfide_then_proline)
     # after serialization


### PR DESCRIPTION
This renames the Polymer.stitch function to `to_rdkit_mol` though an alias `stitch` function is also created for backward compatibility. 

The function is modified for some significant speed up,

1. The function `find_inter_mols_bonds` is not called if it is not needed, since that was already called in the polymer creation. Instead, a class variable is defined that contains the bonds. 
2. The combination of the mols is modified to happen in NlogN time rather than N^2 time. This achieves a significant speed up. 