### PR TITLE
chore: remove prints and progress bar from polymer

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -102,6 +102,7 @@ to run molecular docking and virtual screening.
    Overview <rec_overview>
    Info on templates  <py_build_temp>
    Command line usage <cli_rec_prep>
+   Python bindings <py_rec_prep>
    mk_prepare_receptor.py options <rec_cli_options>
 
 .. toctree::

--- a/docs/source/py_rec_prep.rst
+++ b/docs/source/py_rec_prep.rst
@@ -1,0 +1,66 @@
+Parameterizing receptor from Python
+===================================
+
+Parameterizing the receptor means creating a ``Polymer`` instance. That can
+be done from a PDB string, or directly from a PDB file. The following example
+runs from `test/polymer_data <https://github.com/forlilab/Meeko/tree/develop/test/polymer_data>`_
+using file `AHHY.pdb <https://github.com/forlilab/Meeko/blob/develop/test/polymer_data/AHHY.pdb>`_.
+
+.. code-block:: python
+
+    from meeko import Polymer
+
+    fn = "AHHY.pdb"
+    polymer = Polymer.from_pdb_file(fn)
+
+    # alternatively, use PDB string (not file)
+    with open(fn) as f:
+        pdb_string = f.read()
+    polymer = Polymer.from_pdb_string(pdb_string)
+
+
+The parameterization is performed residue by residue, using the same code that
+parameterizes ligands. To define how to parameterize a receptor, create an
+instance of ``MoleculePreparation`` and pass it to the constructor:
+
+.. code-block:: python
+
+    from meeko import MoleculePreparation
+
+    mk_prep = MoleculePreparation(
+        load_atom_params=["openff-2.3.0"],
+        charge_model="nagl",  # requires a recent version of OpenFF-toolkit
+        merge_these_atom_types=[],
+        rigid_macrocycles=True,
+    )
+    polymer = Polymer.from_pdb_string(pdb_string, mk_prep=mk_prep)
+
+
+Flexible side chains
+--------------------
+
+Make a side chain flexible:
+
+.. code-block:: python
+
+    polymer.flexibilize_sidechain("A:3", mk_prep)
+
+
+And make all rigid again, or one in particular:
+
+.. code-block:: python
+
+    polymer.rigidify_all(mk_prep)
+    polymer.rigidify_sidechain("A:3", mk_prep)
+
+
+The instance of ``mk_prep`` must be passed because flexibilizing and rigidifying side chains
+involves setting bonds as rotatable or not. If the ``mk_prep`` instance is configured
+differently than the one used to parameterize the polymer, than flexibilized and rigidified
+residues will have different parameters. It is possible to reparameterize an entire polymer
+or specific residues:
+
+.. code-block:: python
+
+    polymer.parameterize(mk_prep)
+    polymer.monomers["A:3"].parameterize(mk_prep, "A:3")

--- a/docs/source/py_rec_prep.rst
+++ b/docs/source/py_rec_prep.rst
@@ -35,11 +35,15 @@ instance of ``MoleculePreparation`` and pass it to the constructor:
     )
     polymer = Polymer.from_pdb_string(pdb_string, mk_prep=mk_prep)
 
+See :doc:`lig_prep_advanced` for how to configure ``MoleculePreparation``.
+It is valid for both ligands and receptors.
+
 
 Flexible side chains
 --------------------
 
-Make a side chain flexible:
+Make a side chain flexible. Here, ``"A:3"`` is the residue ID, where
+``A`` is the chain, and ``3`` is the residue number.
 
 .. code-block:: python
 

--- a/meeko/polymer.py
+++ b/meeko/polymer.py
@@ -1809,7 +1809,7 @@ class Polymer(BaseJSONParsable):
     def rigidify_sidechain(self, residue_id, mk_prep):
         if residue_id not in self.get_valid_monomers():
             raise ValueError(f"{residue_id=} not in valid monomers")
-        return self.monomers[residue_id].rigidify(mk_prep)
+        return self.monomers[residue_id].rigidify(mk_prep, residue_id)
 
     def rigidify_all(self, mk_prep):
         for residue_id, monomer in self.get_valid_monomers().items():

--- a/meeko/polymer.py
+++ b/meeko/polymer.py
@@ -36,7 +36,6 @@ from .chemtempgen import build_linked_CCs
 from .preparation import MoleculePreparation
 
 import numpy as np
-from tqdm import tqdm
 
 data_path = files("meeko") / "data"
 periodic_table = Chem.GetPeriodicTable()
@@ -1453,6 +1452,12 @@ class Polymer(BaseJSONParsable):
 
         return polymer
     # endregion
+
+    @classmethod
+    def from_pdb_file(cls, filename, *args, **kwargs):
+        with open(filename) as f:
+            pdb_string = f.read()
+        return cls.from_pdb_string(pdb_string, *args, **kwargs)
     
     @classmethod
     def from_pdb_string(
@@ -1793,10 +1798,8 @@ class Polymer(BaseJSONParsable):
 
         """
 
-        print("    Parametrizing Monomers     ")
-        print("    ----------------------     ")
-        for residue_id in tqdm(self.get_valid_monomers(), desc="Monomers: "):
-            self.monomers[residue_id].parameterize(mk_prep, residue_id, get_atomprop_from_raw = get_atomprop_from_raw)
+        for residue_id, monomer in self.get_valid_monomers().items():
+            monomer.parameterize(mk_prep, residue_id, get_atomprop_from_raw = get_atomprop_from_raw)
 
     def flexibilize_sidechain(self, residue_id, mk_prep):
         if residue_id not in self.get_valid_monomers():


### PR DESCRIPTION
## Description

Remove print statements and progress bar from `Polymer.parameterize()` function. These are very useful when running `mk_prepare_receptor.py` for a single protein, but clutter the stdout when running things in batch. Also, print statements when using the Python bindings directly can be annoying.

Added classmethod `Polymer.from_pdb_file` to spare the user from loading file contents into a string. These method simply wraps the existing `Polymer.from_pdb_string`. Docs added.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Other (please describe):

## Checklist:

Please go through the following checklist before submitting the PR: 

- [x] Written a description of the feature or bug fix above. 
- [x] Ran pytest locally and all tests have passed.
- [x] If applicable, documentation was updated with new feature. 
- [ ] Docstring included for any new classes/functions/methods, or for significantly modifed existing functions. 
- [ ] (Optional) new test added to account for new feature.
