### PR TITLE
feat: add crippen values to molsetup

### DIFF
--- a/meeko/__init__.py
+++ b/meeko/__init__.py
@@ -23,6 +23,7 @@ from .utils import pdbutils
 from .utils import geomutils
 from .utils import utils
 from .atomtyper import AtomTyper
+from .atomtyper import add_crippen_to_molsetup
 from .receptor_pdbqt import PDBQTReceptor
 from .polymer import Polymer
 from .polymer import Monomer

--- a/meeko/atomtyper.py
+++ b/meeko/atomtyper.py
@@ -6,6 +6,7 @@ import warnings
 import numpy as np
 
 from .utils import pdbutils
+from rdkit.Chem import rdMolDescriptors
 
 
 class AtomTyper:
@@ -369,3 +370,12 @@ class AtomicGeometry:
         else:
             # should be np.array
             return vec / l
+
+
+def add_crippen_to_molsetup(molsetup):
+    atom_contribs = rdMolDescriptors._CalcCrippenContribs(molsetup.mol)
+    crippen = [atom[0] for atom in atom_contribs]
+    nr_pseudo_atoms = len(molsetup.atoms) - molsetup.mol.GetNumAtoms()
+    crippen += [0.0] * nr_pseudo_atoms
+    molsetup.atom_params["crippen"] = crippen
+    return None

--- a/meeko/preparation.py
+++ b/meeko/preparation.py
@@ -16,6 +16,7 @@ import meeko.macrocycle
 from .molsetup import Bond
 from .molsetup import RDKitMoleculeSetup
 from .atomtyper import AtomTyper
+from .atomtyper import add_crippen_to_molsetup
 from .espalomatyper import EspalomaTyper
 from .bondtyper import BondTyperLegacy
 from .hydrate import HydrateMoleculeLegacy
@@ -106,7 +107,8 @@ class MoleculePreparation:
         reactive_smarts_idx=None,
         add_index_map=False,
         remove_smiles=False,
-        compute_charges=False
+        compute_charges=False,
+        crippen=False,
     ):
         """
 
@@ -191,6 +193,7 @@ class MoleculePreparation:
         self.charge_model = charge_model
         self.compute_charges = compute_charges
         self.charge_atom_prop = charge_atom_prop
+        self.crippen = crippen
 
         if self.charge_model!="read" and self.charge_atom_prop: 
             raise ValueError(
@@ -662,6 +665,9 @@ class MoleculePreparation:
                 else:
                     new_atom_info = orig_pdbinfo._replace(name=new_name)
                     atom.pdbinfo = new_atom_info
+
+        if self.crippen:
+            add_crippen_to_molsetup(setup)
 
         if self.reactive_smarts is None:
             setups = [setup]


### PR DESCRIPTION
## Description

Add crippen values to molsetup. Example:
```python
mk_prep = MoleculePreparation(crippen=True)
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist:

Please go through the following checklist before submitting the PR: 

- [x] Written a description of the feature or bug fix above. 
- [x] Ran pytest locally and all tests have passed.
- [ ] If applicable, documentation was updated with new feature. 
- [ ] Docstring included for any new classes/functions/methods, or for significantly modifed existing functions. 
- [ ] (Optional) new test added to account for new feature.

