### PR TITLE
Consolidate gasteiger into ad4sol par

### DIFF
--- a/meeko/__init__.py
+++ b/meeko/__init__.py
@@ -24,6 +24,7 @@ from .utils import geomutils
 from .utils import utils
 from .atomtyper import AtomTyper
 from .atomtyper import add_crippen_to_molsetup
+from .atomtyper import set_ad4sol_par_including_q
 from .receptor_pdbqt import PDBQTReceptor
 from .polymer import Polymer
 from .polymer import Monomer

--- a/meeko/atomtyper.py
+++ b/meeko/atomtyper.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import json
+import pathlib
 import warnings
 
 import numpy as np
-
-from .utils import pdbutils
+from rdkit import Chem
 from rdkit.Chem import rdMolDescriptors
 
+from .utils import pdbutils
+from .utils import rdkitutils
+
+pkg_dir = pathlib.Path(__file__).parents[0]
+params_dir = pkg_dir / "data" / "params"
 
 class AtomTyper:
 
@@ -378,4 +384,20 @@ def add_crippen_to_molsetup(molsetup):
     nr_pseudo_atoms = len(molsetup.atoms) - molsetup.mol.GetNumAtoms()
     crippen += [0.0] * nr_pseudo_atoms
     molsetup.atom_params["crippen"] = crippen
+    return None
+
+
+def set_ad4sol_par_including_q(molsetup, qasp):
+    # does not set ad4sol volume
+    par_fn = params_dir / "ad4_desolv_param.json"
+    with open(par_fn) as f:
+        dsolv_params = json.load(f)
+    AtomTyper._type_atoms(molsetup, dsolv_params)
+    charges = rdkitutils.compute_gasteiger_charges(molsetup.mol)
+    nonpolar_h = Chem.MolFromSmarts("[#1][!#7;!#8;!#9;!#16]")
+    for h_idx, parent_idx in molsetup.mol.GetSubstructMatches(nonpolar_h):
+        charges[parent_idx] += charges[h_idx]
+        charges[h_idx] = 0.0
+    for index, charge in enumerate(charges):
+        molsetup.atom_params["ad4_sol_par"][index] += qasp * abs(charge)
     return None

--- a/meeko/preparation.py
+++ b/meeko/preparation.py
@@ -17,6 +17,7 @@ from .molsetup import Bond
 from .molsetup import RDKitMoleculeSetup
 from .atomtyper import AtomTyper
 from .atomtyper import add_crippen_to_molsetup
+from .atomtyper import set_ad4sol_par_including_q
 from .espalomatyper import EspalomaTyper
 from .bondtyper import BondTyperLegacy
 from .hydrate import HydrateMoleculeLegacy
@@ -109,6 +110,8 @@ class MoleculePreparation:
         remove_smiles=False,
         compute_charges=False,
         crippen=False,
+        override_ad4sol_par_including_q=False,
+        override_ad4sol_par_including_q_qasp=0.0,
     ):
         """
 
@@ -194,6 +197,8 @@ class MoleculePreparation:
         self.compute_charges = compute_charges
         self.charge_atom_prop = charge_atom_prop
         self.crippen = crippen
+        self.override_ad4sol_par_including_q = override_ad4sol_par_including_q
+        self.override_ad4sol_par_including_q_qasp = override_ad4sol_par_including_q_qasp
 
         if self.charge_model!="read" and self.charge_atom_prop: 
             raise ValueError(
@@ -668,6 +673,10 @@ class MoleculePreparation:
 
         if self.crippen:
             add_crippen_to_molsetup(setup)
+
+        if self.override_ad4sol_par_including_q:
+            qasp = self.override_ad4_sol_par_including_q_qasp
+            set_ad4_sol_par_including_q(setup, qasp)
 
         if self.reactive_smarts is None:
             setups = [setup]

--- a/meeko/preparation.py
+++ b/meeko/preparation.py
@@ -9,6 +9,7 @@ import json
 eol="\n"
 import pathlib
 import warnings
+import logging
 
 from rdkit import Chem
 
@@ -48,7 +49,7 @@ params_dir = pkg_dir / "data" / "params"
 
 # DeprecationWarning is not displayed by default
 warnings.filterwarnings("default", category=DeprecationWarning)
-
+logger = logging.getLogger(__name__)
 
 class MoleculePreparation:
     """
@@ -280,9 +281,8 @@ class MoleculePreparation:
         """
         expected_keys = cls.get_defaults_dict().keys()
         bad_keys = [k for k in config if k not in expected_keys]
-        if bad_keys:
-            warnings.warn(f"Ignore unexpected keys: {bad_keys}")
-        config = {k: v for k,v in config.items() if k in expected_keys}
+        for bad_key in bad_keys:
+            logger.error(f"Unexpected key: {bad_key}")
         p = cls(**config)
         return p
     

--- a/meeko/preparation.py
+++ b/meeko/preparation.py
@@ -675,8 +675,8 @@ class MoleculePreparation:
             add_crippen_to_molsetup(setup)
 
         if self.override_ad4sol_par_including_q:
-            qasp = self.override_ad4_sol_par_including_q_qasp
-            set_ad4_sol_par_including_q(setup, qasp)
+            qasp = self.override_ad4sol_par_including_q_qasp
+            set_ad4sol_par_including_q(setup, qasp)
 
         if self.reactive_smarts is None:
             setups = [setup]

--- a/test/parameterization_test.py
+++ b/test/parameterization_test.py
@@ -4,6 +4,8 @@ import pathlib
 from rdkit import Chem
 from rdkit.Chem import rdDistGeom
 from meeko import MoleculePreparation
+from meeko import set_ad4sol_par_including_q
+import numpy as np
 import meeko
 import pytest
 
@@ -119,3 +121,24 @@ def test_mbondi():
     assert 1.2 not in molsetup.atom_params["mbondi_radius"]  # other H
     assert molsetup.atom_params["gb_screen"].count(0.72) == 4  # C
     assert molsetup.atom_params["gb_screen"].count(0.79) == 2  # N
+
+def test_override_ad4sol_par_including_q():
+    qasp = 0.01097
+    mol = Chem.AddHs(Chem.MolFromSmiles("c1nc[nH]c1CO"))
+    etkdg_v3 = rdDistGeom.ETKDGv3()
+    rdDistGeom.EmbedMolecule(mol, etkdg_v3)
+    mk_prep = MoleculePreparation(load_atom_params=["ad4_types", "ad4_desolv_volume", "ad4_desolv_param"])
+    molsetup_default = mk_prep(mol)[0]
+    ref_par = np.array(molsetup_default.atom_params["ad4_sol_par"])
+    ref_par += qasp * np.abs([atom.charge for atom in molsetup_default.atoms])
+    mk_prep_mod = MoleculePreparation(
+        charge_model="zero", 
+        merge_these_atom_types=[],
+    )
+    molsetup_mod = mk_prep_mod(mol)[0]
+    set_ad4sol_par_including_q(molsetup_mod, qasp)
+    mod_par = np.array(molsetup_mod.atom_params["ad4_sol_par"]) 
+    assert np.max(np.abs([atom.charge for atom in molsetup_default.atoms])) > np.finfo(float).eps
+    assert np.max(np.abs([atom.charge for atom in molsetup_mod.atoms])) < np.finfo(float).eps
+    assert np.max(np.abs(ref_par - mod_par)) < np.finfo(float).eps
+    assert np.max(np.abs(ref_par)) > np.finfo(float).eps

--- a/test/parameterization_test.py
+++ b/test/parameterization_test.py
@@ -4,7 +4,6 @@ import pathlib
 from rdkit import Chem
 from rdkit.Chem import rdDistGeom
 from meeko import MoleculePreparation
-from meeko import set_ad4sol_par_including_q
 import numpy as np
 import meeko
 import pytest
@@ -134,9 +133,10 @@ def test_override_ad4sol_par_including_q():
     mk_prep_mod = MoleculePreparation(
         charge_model="zero", 
         merge_these_atom_types=[],
+        override_ad4sol_par_including_q=True,
+        override_ad4sol_par_including_q_qasp=qasp,
     )
     molsetup_mod = mk_prep_mod(mol)[0]
-    set_ad4sol_par_including_q(molsetup_mod, qasp)
     mod_par = np.array(molsetup_mod.atom_params["ad4_sol_par"]) 
     assert np.max(np.abs([atom.charge for atom in molsetup_default.atoms])) > np.finfo(float).eps
     assert np.max(np.abs([atom.charge for atom in molsetup_mod.atoms])) < np.finfo(float).eps


### PR DESCRIPTION
Add argument `override_ad4sol_par_including_q` to MoleculePreparation, which defaults to `False`. Works together with argument `override_ad4sol_par_including_q_qasp` which defines the `qasp` (float) value. When enabled, key `ad4_sol_par` in `molsetup.atom_params` is set to the default AD4 solvation parameter plus the absolute value of the Gasteiger charge after merging non-polar Hs. The goal is to enable the use of AD4 solvation with arbitrary charge models for electrostatics and arbitrary merging of Hs. Qasp must be set to zero during docking.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist:

Please go through the following checklist before submitting the PR: 

- [ ] Written a description of the feature or bug fix above. 
- [x] Ran pytest locally and all tests have passed.
- [ ] If applicable, documentation was updated with new feature. 
- [ ] Docstring included for any new classes/functions/methods, or for significantly modifed existing functions. 
- [x] (Optional) new test added to account for new feature.
