### PR TITLE
feat: exclude parameters in UniqAtomParams

### DIFF
--- a/meeko/molsetup.py
+++ b/meeko/molsetup.py
@@ -159,7 +159,8 @@ class UniqAtomParams:
         return new_row_index
 
     def add_molsetup(
-        self, molsetup, atom_params=None, add_atomic_nr=False, add_atom_type=False
+        self, molsetup, atom_params=None, add_atomic_nr=False, add_atom_type=False,
+        remove_params=(),
     ):
         if "charge" in molsetup.atom_params or "atom_type" in molsetup.atom_params:
             msg = '"charge" and "atom_type" found in molsetup.atom_params'
@@ -173,7 +174,7 @@ class UniqAtomParams:
             if atom.is_ignore:
                 param_idx = None
             else:
-                p = {k: v[atom.index] for (k, v) in molsetup.atom_params.items()}
+                p = {k: v[atom.index] for (k, v) in molsetup.atom_params.items() if k not in remove_params}
                 if add_atomic_nr:
                     if "atomic_nr" in p:
                         raise RuntimeError(


### PR DESCRIPTION
Add option to exclude parameters when adding to UniqAtomParams. The resulting set of unique parameters will not consider the excluded parameters. Option is named `remove_params` and is available in the `add_molsetup` method.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist:

Please go through the following checklist before submitting the PR: 

- [x] Written a description of the feature or bug fix above. 
- [x] Ran pytest locally and all tests have passed.
- [ ] If applicable, documentation was updated with new feature. 
- [ ] Docstring included for any new classes/functions/methods, or for significantly modifed existing functions. 
- [ ] (Optional) new test added to account for new feature.

## Additional Information
