### PR TITLE
fix: set covalent radious of Cu and K to zero

### DIFF
--- a/meeko/utils/covalent_radius_table.py
+++ b/meeko/utils/covalent_radius_table.py
@@ -132,6 +132,6 @@ covalent_radius = {
 }
 
 # hack to avoid bonds with common salts and metals
-salts_and_metals = ["Na", "Mg", "Ca", "Mn", "Fe", "Zn"]
+salts_and_metals = ["Na", "Mg", "Ca", "Mn", "Fe", "Zn", "Cu", "K"]
 for element in salts_and_metals:
     covalent_radius[element] = 0.0


### PR DESCRIPTION
## Description

Covalent radius of metals and salts are set to zero to prevent bond perception with neighboring residues. This is necessary because the templates are designed for a non-bonded model.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist:

Please go through the following checklist before submitting the PR: 

- [ ] Written a description of the feature or bug fix above. 
- [ ] Ran pytest locally and all tests have passed.
- [ ] If applicable, documentation was updated with new feature. 
- [ ] Docstring included for any new classes/functions/methods, or for significantly modifed existing functions. 
- [ ] (Optional) new test added to account for new feature.