### PR TITLE
fix: support add_atom_types with multiple groups in load_atom_params

### DIFF
--- a/meeko/preparation.py
+++ b/meeko/preparation.py
@@ -468,15 +468,20 @@ class MoleculePreparation:
             atom_params.update(d)
 
         if add_atom_types is not None and len(add_atom_types) > 0:
-            group_keys = list(atom_params.keys())
-            if len(group_keys) != 1:
-                msg = "add_atom_types is usable only when there is one group of parameters"
+            group_keys_that_set_atype = set()
+            for group_key, entries in atom_params.items():
+                for entry in entries:
+                    if "atype" in entry:
+                        group_keys_that_set_atype.add(group_key)
+                        break
+            if len(group_keys_that_set_atype) != 1:
+                msg = "add_atom_types is usable only when there is one group of parameters that sets 'atype'"
                 msg += ", but there are %d groups: %s" % (
-                    len(group_keys),
-                    str(group_keys),
+                    len(group_keys_that_set_atype),
+                    str(group_keys_that_set_atype),
                 )
                 raise RuntimeError(msg)
-            key = group_keys[0]
+            key = group_keys_that_set_atype.pop()
             atom_params[key].extend(add_atom_types)
 
         return atom_params

--- a/test/parameterization_test.py
+++ b/test/parameterization_test.py
@@ -142,3 +142,14 @@ def test_override_ad4sol_par_including_q():
     assert np.max(np.abs([atom.charge for atom in molsetup_mod.atoms])) < np.finfo(float).eps
     assert np.max(np.abs(ref_par - mod_par)) < np.finfo(float).eps
     assert np.max(np.abs(ref_par)) > np.finfo(float).eps
+
+def test_add_atom_types_with_multiple_typing_groups():
+    mol = Chem.AddHs(Chem.MolFromSmiles("c1nc[nH]c1CO"))
+    etkdg_v3 = rdDistGeom.ETKDGv3()
+    rdDistGeom.EmbedMolecule(mol, etkdg_v3)
+    mk_prep = MoleculePreparation(
+        load_atom_params=["ad4_types", "gb_mbondi"],
+        add_atom_types=[{"smarts": "[#1]", "atype": "H"}],
+    )
+    molsetup = mk_prep(mol)[0]
+    return


### PR DESCRIPTION
## Description

Parameters are grouped in separate lists, e.g. AD4 atom types in one list, and solvation parameters in another. See files in https://github.com/forlilab/Meeko/tree/develop/meeko/data/params. The argument `add_atom_types` extends one of the lists with new rules and SMARTS patters to assign the `atype` field. This PR updates the requirement from the existence of a single list, to allowing multiple lists as long as only one of the lists sets the `atype` field.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist:

Please go through the following checklist before submitting the PR: 

- [x] Written a description of the feature or bug fix above. 
- [x] Ran pytest locally and all tests have passed.
- [ ] If applicable, documentation was updated with new feature. 
- [ ] Docstring included for any new classes/functions/methods, or for significantly modifed existing functions. 
- [x] (Optional) new test added to account for new feature.
