### PR TITLE
fix: Polymer.to_rdkit_mol with user specified residues - thanks Andreas

### DIFF
--- a/meeko/polymer.py
+++ b/meeko/polymer.py
@@ -1371,7 +1371,7 @@ class Polymer(BaseJSONParsable):
             if self.bonds is None or not self.bonds: 
                 bonds_indexed_in_raw = find_inter_mols_bonds(resid_to_rawmols)
             else:
-                bonds_indexed_in_raw = self.bonds
+                bonds_indexed_in_raw = {(r1, r2): v for (r1, r2), v in self.bonds.items() if r1 in residues_to_add and r2 in residues_to_add}
 
             invmaps = {
                 res_id: {j: i for i, j in self.monomers[res_id].mapidx_to_raw.items()}


### PR DESCRIPTION
## Description

When only a few selected residues are to be stiched (converted to rdkit mol), the loop that iterates through the bonds was looping over all residues, not just the selected one. Now it loops over only the bonds relevant to the selected residues.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist:

Please go through the following checklist before submitting the PR: 

- [ ] Written a description of the feature or bug fix above. 
- [x] Ran pytest locally and all tests have passed.
- [ ] If applicable, documentation was updated with new feature. 
- [ ] Docstring included for any new classes/functions/methods, or for significantly modifed existing functions. 
- [ ] (Optional) new test added to account for new feature.