### PR TITLE
option to ignore faulty residues with --rot_term_group option

### DIFF
--- a/docs/source/rec_cli_options.rst
+++ b/docs/source/rec_cli_options.rst
@@ -147,7 +147,8 @@ Flexible and/or Reactive Options
 .. option:: -t, --rot_terminal_group <residues>
 
    specify the residues for which to make terminal functional group rotatable by the chain ID and residue number, 
-   e.g. -t ":42,B:23" is equivalent to -t ":42" -t "B:23" (leave chain ID empty if omitted in input PDB or mmCIF)'
+   e.g. -t ":42,B:23" is equivalent to -t ":42" -t "B:23" (leave chain ID empty if omitted in input PDB or mmCIF)
+   If used in conjunction with `--delete_bad_res`, invalid residues will be ignored. Otherwise the program will crash. 
 
 .. option:: --r_eq_12 <value>
 

--- a/meeko/cli/mk_prepare_receptor.py
+++ b/meeko/cli/mk_prepare_receptor.py
@@ -207,7 +207,9 @@ def get_args():
         "--rot_terminal_group",
         action="append",
         default=[],
-        help='specify the residues for which to make terminal functional group rotatable by the chain ID and residue number, e.g. -t ":42,B:23" is equivalent to -t ":42" -t "B:23" (leave chain ID empty if omitted in input PDB or mmCIF)',
+        help='''specify the residues for which to make terminal functional group rotatable by the chain ID and residue number,
+                e.g. -t ":42,B:23" is equivalent to -t ":42" -t "B:23" (leave chain ID empty if omitted in input PDB or mmCIF).
+                If used in conjunction with --delete_bad_res, invalid residues will be ignored. Otherwise, the program will crash.''',
     )
 
     

--- a/meeko/cli/mk_prepare_receptor.py
+++ b/meeko/cli/mk_prepare_receptor.py
@@ -734,13 +734,34 @@ def main():
         "THR",
         "MET",
     ]
+    valid_rot_res = len(rot_term_res)
+    valid_res = []
     for res_id in rot_term_res:
         if res_id not in polymer.monomers:
             print("resid %s not found in input receptor file" % res_id)
             sys.exit(2)
         input_resname = polymer.monomers[res_id].input_resname
+
         if input_resname not in rotatable_termgrp_residues_allowed:
-            print(f"{input_resname} (resid {res_id}) is not a valid residue for use with --rot_terminal_group."+ eol)
+            if delete_bad_res: 
+                print(f"{input_resname} (resid {res_id}) invalid for --rot_terminal_group, but --delete_bad_res was used, so it will be ignored.")
+                valid_rot_res -= 1
+            else:
+                print(f"{input_resname} (resid {res_id}) is not a valid residue for use with --rot_terminal_group."+ eol)
+                print("Available residues are: ")
+                print(", ".join(rotatable_termgrp_residues_allowed))
+                sys.exit(2)
+        else: 
+            valid_res.append(res_id)
+
+    
+    ## select only valid terminal residues if right options are chosen:
+    if delete_bad_res and len(rot_term_res) > 0: 
+        if valid_rot_res > 0:
+            print(f"{valid_rot_res} out of {len(rot_term_res)} are valid for --rot_terminal_group. Proceed with those.")
+            rot_term_res = valid_res
+        else:
+            print("No valid residues provided for use with --rot_term_group")
             print("Available residues are: ")
             print(", ".join(rotatable_termgrp_residues_allowed))
             sys.exit(2)


### PR DESCRIPTION
## Description

This is a small feature that changes how `--rot_term_group` functions when used together with `--delete_bad_res` (or `--allow_bad_res`). Instead of crashing as soon as it detects an invalid residue, meeko will simply ignore it and proceed with the valid ones, as long as one within the provided list is a valid residue for terminal rotation. If none is valid, then it will crash. A warning will be printed in either case. 

This is a small QOL change that will allow the user to apply both -f and -t options with the same list of residues. It may save some time from having to select a different set of residue IDs for the two different options. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist:

Please go through the following checklist before submitting the PR: 

- [x] Written a description of the feature or bug fix above. 
- [x] Ran pytest locally and all tests have passed.
- [x] If applicable, documentation was updated with new feature. 
- [ ] Docstring included for any new classes/functions/methods, or for significantly modifed existing functions. 
- [ ] (Optional) new test added to account for new feature.

## Additional Information

I think this qualifies as a "breaking" change since it changes an existing feature, but it's very minor and only applies to the CLI, not the API. 