### PR TITLE
fix: replace removed np.int alias in PDBQTMolecule.atoms

### DIFF
--- a/meeko/molecule_pdbqt.py
+++ b/meeko/molecule_pdbqt.py
@@ -486,8 +486,8 @@ class PDBQTMolecule:
 
         """
         if atom_idx is not None:
-            if not isinstance(atom_idx, (list, tuple, np.ndarray)):
-                atom_idx = np.array(atom_idx, dtype=np.int)
+            if isinstance(atom_idx, (int, np.integer)):
+                atom_idx = [int(atom_idx)]
         else:
             atom_idx = np.arange(0, self._atoms.shape[0])
 

--- a/test/pdbqtmol_atoms_test.py
+++ b/test/pdbqtmol_atoms_test.py
@@ -1,0 +1,40 @@
+from meeko import PDBQTMolecule
+import numpy as np
+import pathlib
+
+workdir = pathlib.Path(__file__)
+datadir = workdir.parents[0] / "rdkitmol_from_docking_data"
+
+fpath = datadir / "vina-result-ethanol.pdbqt"
+
+
+def test_atoms_all():
+    pdbqtmol = PDBQTMolecule.from_file(fpath)
+    assert len(pdbqtmol.atoms()) == pdbqtmol._atoms.shape[0]
+
+
+def test_atoms_scalar_index():
+    pdbqtmol = PDBQTMolecule.from_file(fpath)
+    atoms = pdbqtmol.atoms(0)
+    assert len(atoms) == 1
+    assert atoms[0]["idx"] == 0
+
+
+def test_atoms_numpy_scalar_index():
+    pdbqtmol = PDBQTMolecule.from_file(fpath)
+    atoms = pdbqtmol.atoms(np.int64(1))
+    assert len(atoms) == 1
+    assert atoms[0]["idx"] == 1
+
+
+def test_atoms_sequence_index():
+    pdbqtmol = PDBQTMolecule.from_file(fpath)
+    for idx in ([0, 2], (0, 2), np.array([0, 2])):
+        atoms = pdbqtmol.atoms(idx)
+        assert [a["idx"] for a in atoms] == [0, 2]
+
+
+def test_positions_scalar_index():
+    pdbqtmol = PDBQTMolecule.from_file(fpath)
+    xyz = pdbqtmol.positions(0)
+    assert xyz.shape == (1, 3)


### PR DESCRIPTION
## Description

`PDBQTMolecule.atoms()` calls `np.array(atom_idx, dtype=np.int)` when given an integer index. `np.int` was deprecated in NumPy 1.20 and removed in 1.24, so this raises `AttributeError` on any recent NumPy. Neither `requirements.txt` nor `setup.py` constrains the NumPy version, so a fresh install hits it:

```
>>> pdbqtmol.atoms(0)
AttributeError: module 'numpy' has no attribute 'int'
```

The `isinstance` check around it is also inverted. It ran the conversion for anything that was not a list, tuple, or ndarray, so it converted scalars into 0-d arrays (which then break the `set(atom_idx)` call two lines below) while leaving actual sequences untouched. The intent was clearly the opposite. This changes it to wrap a scalar index in a list, and leaves sequences alone:

```python
if atom_idx is not None:
    if isinstance(atom_idx, (int, np.integer)):
        atom_idx = [int(atom_idx)]
```

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist:

Please go through the following checklist before submitting the PR: 

- [x] Written a description of the feature or bug fix above. 
- [x] Ran pytest locally and all tests have passed.
- [ ] If applicable, documentation was updated with new feature. 
- [ ] Docstring included for any new classes/functions/methods, or for significantly modifed existing functions. 
- [x] (Optional) new test added to account for new feature.

## Additional Information

Adds `test/pdbqtmol_atoms_test.py` covering scalar, NumPy scalar, and sequence indices for `atoms()`, plus the scalar path through `positions()`. Three of the five fail on `develop` with the `AttributeError` above and pass with this change. Full suite goes from 94 passed / 4 skipped to 99 passed / 4 skipped.

Tested against NumPy 2.5.1, SciPy 1.18.0, RDKit 2026.03.5 on Python 3.13. Worth noting that `PDBQTReceptor.atoms()` in `receptor_pdbqt.py` has the same inverted `isinstance` check, though it uses the builtin `int` rather than `np.int` so it does not crash. Left alone to keep this PR to one issue.
