### PR TITLE
fix: keep receptor atom index aligned with the atoms array

### DIFF
--- a/meeko/receptor_pdbqt.py
+++ b/meeko/receptor_pdbqt.py
@@ -41,7 +41,6 @@ def _read_receptor_pdbqt_string(pdbqt_string, skip_typing=False):
     # TZ is a pseudo atom for AutoDock4Zn FF
     pseudo_atom_types = ['TZ']
 
-    idx = 0
     for line in pdbqt_string.split(eol):
         if line.startswith('ATOM') or line.startswith("HETATM"):
             serial = int(line[6:11].strip())
@@ -67,19 +66,20 @@ def _read_receptor_pdbqt_string(pdbqt_string, skip_typing=False):
                 temp_factor = None
             record_type = line[0:6].strip()
 
-            if skip_typing:
-                atoms.append((idx, serial, name, resid, resname, chainid, xyz, partial_charges, atom_type,
-                              alt_id, in_code, occupancy, temp_factor, record_type))
+            if not skip_typing and atom_type in pseudo_atom_types:
                 continue
-            if not atom_type in pseudo_atom_types:
+
+            # idx must stay equal to the row position in atoms, because the
+            # annotation lists are used to index into it
+            idx = len(atoms)
+            if not skip_typing:
                 atom_annotations['all'].append(idx)
                 atom_annotations[atom_property_definitions[atom_type]].append(idx)
-                atoms.append((idx, serial, name, resid, resname, chainid, xyz, partial_charges, atom_type,
-                              alt_id, in_code, occupancy, temp_factor, record_type))
+            atoms.append((idx, serial, name, resid, resname, chainid, xyz, partial_charges, atom_type,
+                          alt_id, in_code, occupancy, temp_factor, record_type))
 
-            idx += 1
-    if idx == 0:
-        raise ValueError(f"no atoms found in {pdbqt_string=}") 
+    if not atoms:
+        raise ValueError(f"no atoms found in {pdbqt_string=}")
     atoms = np.array(atoms, dtype=atoms_dtype)
 
     return atoms, atom_annotations

--- a/test/receptor_pdbqt_test.py
+++ b/test/receptor_pdbqt_test.py
@@ -1,0 +1,63 @@
+from meeko.receptor_pdbqt import PDBQTReceptor
+from meeko.receptor_pdbqt import _read_receptor_pdbqt_string
+
+# three typed atoms, no pseudo atoms
+PDBQT = "\n".join([
+    "ATOM      1  N   ALA A   1      11.104  13.207  10.000  1.00  0.00    -0.347 N ",
+    "ATOM      2  CA  ALA A   1      12.560  13.207  10.000  1.00  0.00     0.180 C ",
+    "ATOM      3  O   ALA A   1      13.100  14.600  10.000  1.00  0.00    -0.271 OA",
+]) + "\n"
+
+# same, with an AutoDock4Zn TZ pseudo atom in the middle
+PDBQT_TZ = "\n".join([
+    "ATOM      1  N   ALA A   1      11.104  13.207  10.000  1.00  0.00    -0.347 N ",
+    "ATOM      2  TZ  ZN  A   2      12.000  13.000  10.000  1.00  0.00     0.000 TZ",
+    "ATOM      3  CA  ALA A   3      12.560  13.207  10.000  1.00  0.00     0.180 C ",
+    "ATOM      4  O   ALA A   3      13.100  14.600  10.000  1.00  0.00    -0.271 OA",
+]) + "\n"
+
+
+def check_idx_matches_row(atoms):
+    for row, atom in enumerate(atoms):
+        assert atom["idx"] == row
+
+
+def test_idx_matches_row():
+    atoms, annotations = _read_receptor_pdbqt_string(PDBQT)
+    assert len(atoms) == 3
+    check_idx_matches_row(atoms)
+
+
+def test_skip_typing_reads_atoms():
+    atoms, annotations = _read_receptor_pdbqt_string(PDBQT, skip_typing=True)
+    assert len(atoms) == 3
+    check_idx_matches_row(atoms)
+
+
+def test_skip_typing_on_receptor():
+    receptor = PDBQTReceptor(PDBQT, skip_typing=True)
+    assert receptor._atoms.shape[0] == 3
+
+
+def test_pseudo_atom_is_dropped():
+    atoms, annotations = _read_receptor_pdbqt_string(PDBQT_TZ)
+    assert len(atoms) == 3
+    assert "TZ" not in list(atoms["atom_type"])
+    check_idx_matches_row(atoms)
+
+
+def test_annotations_index_correct_rows():
+    atoms, annotations = _read_receptor_pdbqt_string(PDBQT_TZ)
+    assert annotations["all"] == [0, 1, 2]
+    # the OA follows the dropped TZ, so its row shifts down by one
+    assert annotations["hb_acc"] == [2]
+    assert atoms[annotations["hb_acc"][0]]["atom_type"] == "OA"
+    assert sorted(atoms[i]["atom_type"] for i in annotations["vdw"]) == ["C", "N"]
+
+
+def test_no_atoms_raises():
+    try:
+        _read_receptor_pdbqt_string("REMARK nothing here\n")
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for a string with no atoms")


### PR DESCRIPTION
## Description

`_read_receptor_pdbqt_string` keeps a manual `idx` counter that is stored in each atom record and appended to the annotation lists. Those annotation lists are then used to index into the `atoms` array, in `_identify_bonds` and in `closest_atoms_from_positions`, so `idx` has to equal the row position. It can drift from it in two ways.

With `skip_typing=True`, the append branch hits `continue` before reaching `idx += 1`, so `idx` never leaves 0. Every atom is stored with index 0, and because the end of the function checks `if idx == 0` to decide whether anything was read, the guard fires no matter how many atoms were parsed. `skip_typing=True` currently cannot be used at all, through either this function or the `PDBQTReceptor` constructor:

```
>>> PDBQTReceptor(pdbqt_string, skip_typing=True)   # 3 atoms in the string
ValueError: no atoms found in pdbqt_string=...
```

TZ pseudo atoms are deliberately excluded from the `atoms` array, but they still advance `idx`. Every annotation index recorded after a TZ is therefore one too high. On a receptor with a TZ at row 1, `all` comes out as `[0, 2, 3]` for a 3 row array, so the hydrogen bond and metal annotations point at the wrong atoms, or past the end. TZ is the AutoDock4Zn pseudo atom, so this affects the zinc metalloprotein receptors it exists to support.

This derives the index from `len(atoms)` at append time, so it matches the row position by construction and the counter can no longer drift. The two duplicated `atoms.append(...)` calls are merged into one while they are being touched, since having the same tuple built in two branches is what let the two paths disagree in the first place. TZ handling and the `skip_typing` semantics are otherwise unchanged.

No linked issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist:

Please go through the following checklist before submitting the PR: 

- [x] Written a description of the feature or bug fix above. 
- [x] Ran pytest locally and all tests have passed.
- [ ] If applicable, documentation was updated with new feature. 
- [ ] Docstring included for any new classes/functions/methods, or for significantly modifed existing functions. 
- [x] (Optional) new test added to account for new feature.

## Additional Information

Adds `test/receptor_pdbqt_test.py`, which had no coverage before. Six tests covering index alignment, `skip_typing` through both the function and `PDBQTReceptor`, TZ exclusion, annotation alignment across a dropped TZ, and the empty input guard. Four of the six fail on `develop` and all pass with this change. Full suite goes from 94 passed / 4 skipped to 100 passed / 4 skipped.

Anyone relying on the current behaviour of reading the `idx` field as a position in the input file rather than a row in the returned array would see a change, but that reading is inconsistent with how the annotations are consumed, so it seems safe to treat as a bug rather than an interface.
