### PR TITLE
perf: query the KD-tree once per structure in _identify_bonds

### DIFF
--- a/meeko/molecule_pdbqt.py
+++ b/meeko/molecule_pdbqt.py
@@ -315,16 +315,19 @@ def _identify_bonds(atom_idx, positions, atom_types):
     k = 5 if len(atom_idx) > 5 else len(atom_idx)
     atom_idx = np.array(atom_idx)
 
-    # If there is only one atom, we know there won't be a single bond..
-    if len(atom_idx) == 1:
+    # with fewer than two atoms there is no neighbor to bond to
+    if k < 2:
         return bonds
 
-    for atom_i, position, atom_type in zip(atom_idx, positions, atom_types):
-        distances, indices = KDTree.query(position, k=k)
-        r_cov = covalent_radius[autodock4_atom_types_elements[atom_type]]
+    # query every atom in one call, so the search stays in C
+    distances, indices = KDTree.query(positions, k=k, workers=-1)
+    neighbors = indices[:, 1:]
+    r_cov = np.array([covalent_radius[autodock4_atom_types_elements[t]] for t in atom_types])
+    optimal_distances = bond_allowance_factor * (r_cov[:, None] + r_cov[neighbors])
+    is_bonded = distances[:, 1:] < optimal_distances
 
-        optimal_distances = [bond_allowance_factor * (r_cov + covalent_radius[autodock4_atom_types_elements[atom_types[i]]]) for i in indices[1:]]
-        bonds[atom_i] = atom_idx[indices[1:][np.where(distances[1:] < optimal_distances)]].tolist()
+    for i, atom_i in enumerate(atom_idx):
+        bonds[atom_i] = atom_idx[neighbors[i][is_bonded[i]]].tolist()
 
     return bonds
 

--- a/meeko/receptor_pdbqt.py
+++ b/meeko/receptor_pdbqt.py
@@ -94,12 +94,19 @@ def _identify_bonds(atom_idx, positions, atom_types):
     k = 5 if len(atom_idx) > 5 else len(atom_idx)
     atom_idx = np.array(atom_idx)
 
-    for atom_i, position, atom_type in zip(atom_idx, positions, atom_types):
-        distances, indices = KDTree.query(position, k=k)
-        r_cov = covalent_radius[autodock4_atom_types_elements[atom_type]]
+    # with fewer than two atoms there is no neighbor to bond to
+    if k < 2:
+        return bonds
 
-        optimal_distances = [bond_allowance_factor * (r_cov + covalent_radius[autodock4_atom_types_elements[atom_types[i]]]) for i in indices[1:]]
-        bonds[atom_i] = atom_idx[indices[1:][np.where(distances[1:] < optimal_distances)]].tolist()
+    # query every atom in one call, so the search stays in C
+    distances, indices = KDTree.query(positions, k=k, workers=-1)
+    neighbors = indices[:, 1:]
+    r_cov = np.array([covalent_radius[autodock4_atom_types_elements[t]] for t in atom_types])
+    optimal_distances = bond_allowance_factor * (r_cov[:, None] + r_cov[neighbors])
+    is_bonded = distances[:, 1:] < optimal_distances
+
+    for i, atom_i in enumerate(atom_idx):
+        bonds[atom_i] = atom_idx[neighbors[i][is_bonded[i]]].tolist()
 
     return bonds
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 gemmi
 rdkit
-scipy
+scipy>=1.6
 tomli
 tqdm

--- a/test/identify_bonds_test.py
+++ b/test/identify_bonds_test.py
@@ -1,0 +1,87 @@
+import numpy as np
+
+from meeko.molecule_pdbqt import _identify_bonds as identify_bonds_ligand
+from meeko.receptor_pdbqt import _identify_bonds as identify_bonds_receptor
+from meeko.utils.covalent_radius_table import covalent_radius
+from meeko.utils.autodock4_atom_types_elements import autodock4_atom_types_elements
+
+implementations = (identify_bonds_ligand, identify_bonds_receptor)
+
+
+def run_both(atom_idx, positions, atom_types):
+    """both modules carry the same function, so check them together"""
+    results = []
+    for identify_bonds in implementations:
+        bonds = identify_bonds(atom_idx, np.array(positions, dtype=np.float32),
+                               np.array(atom_types))
+        results.append({int(k): sorted(int(i) for i in v) for k, v in bonds.items()})
+    assert results[0] == results[1]
+    return results[0]
+
+
+def test_two_bonded_carbons():
+    # 1.5 A apart, well inside 1.1 * (0.76 + 0.76)
+    bonds = run_both([0, 1], [[0.0, 0.0, 0.0], [1.5, 0.0, 0.0]], ["C", "C"])
+    assert bonds == {0: [1], 1: [0]}
+
+
+def test_two_distant_carbons():
+    # 2.5 A apart, outside the covalent cutoff
+    bonds = run_both([0, 1], [[0.0, 0.0, 0.0], [2.5, 0.0, 0.0]], ["C", "C"])
+    assert bonds == {0: [], 1: []}
+
+
+def test_methane_like():
+    # central carbon with four hydrogens at 1.09 A
+    d = 1.09 / np.sqrt(3.0)
+    positions = [[0.0, 0.0, 0.0], [d, d, d], [-d, -d, d], [d, -d, -d], [-d, d, -d]]
+    bonds = run_both([0, 1, 2, 3, 4], positions, ["C", "HD", "HD", "HD", "HD"])
+    assert bonds[0] == [1, 2, 3, 4]
+    for h in (1, 2, 3, 4):
+        assert bonds[h] == [0]
+
+
+def reference_bonds(atom_idx, positions, atom_types):
+    """brute force version of the same rule, for comparison"""
+    positions = np.asarray(positions, dtype=np.float64)
+    n = len(atom_idx)
+    k = 5 if n > 5 else n
+    radii = [covalent_radius[autodock4_atom_types_elements[t]] for t in atom_types]
+    bonds = {}
+    for i in range(n):
+        d = np.linalg.norm(positions - positions[i], axis=1)
+        nearest = np.argsort(d, kind="stable")[1:k]
+        bonds[int(atom_idx[i])] = sorted(
+            int(atom_idx[j]) for j in nearest
+            if d[j] < 1.1 * (radii[i] + radii[j])
+        )
+    return bonds
+
+
+def test_matches_brute_force_reference():
+    rng = np.random.RandomState(0)
+    for trial in range(20):
+        n = int(rng.randint(2, 120))
+        positions = (rng.rand(n, 3) * rng.uniform(3.0, 14.0)).astype(np.float32)
+        atom_types = np.array([["C", "N", "OA", "HD", "SA"][i]
+                               for i in rng.randint(0, 5, n)])
+        got = run_both(list(range(n)), positions, atom_types)
+        want = reference_bonds(list(range(n)), positions, atom_types)
+        assert got == want
+
+
+def test_non_contiguous_indices():
+    # annotation lists are subsets, so keys must be the given indices
+    positions = [[0.0, 0.0, 0.0], [1.5, 0.0, 0.0], [10.0, 0.0, 0.0]]
+    bonds = run_both([4, 7, 9], positions, ["C", "C", "C"])
+    assert bonds == {4: [7], 7: [4], 9: []}
+
+
+def test_single_atom():
+    bonds = run_both([0], [[0.0, 0.0, 0.0]], ["C"])
+    assert bonds == {}
+
+
+def test_no_atoms():
+    bonds = run_both([], np.empty((0, 3)), np.array([], dtype="U2"))
+    assert bonds == {}


### PR DESCRIPTION
## Description

`_identify_bonds` loops over every atom in Python and issues one `KDTree.query` call per atom, then builds a list comprehension of cutoff distances for each one. On an 80k atom receptor that is 80k round trips through scipy. Profiling `PDBQTReceptor(pdbqt_string)` on an 80k atom input puts it at 1.738 s of a 2.441 s total, so roughly 70 percent of the time spent building a receptor is in this one function.

`cKDTree.query` already accepts the whole coordinate array at once. This changes the function to make a single query for the entire structure with `workers=-1`, and turns the radius lookup and cutoff comparison into array operations. Only the final dict assembly stays in Python:

```python
distances, indices = KDTree.query(positions, k=k, workers=-1)
neighbors = indices[:, 1:]
r_cov = np.array([covalent_radius[autodock4_atom_types_elements[t]] for t in atom_types])
optimal_distances = bond_allowance_factor * (r_cov[:, None] + r_cov[neighbors])
is_bonded = distances[:, 1:] < optimal_distances
```

The function is duplicated verbatim in `molecule_pdbqt.py` and `receptor_pdbqt.py`, so both copies get the same change and remain identical to each other. Deduplicating them is worth doing separately and is not attempted here.

No linked issue.

## Timing

`_identify_bonds` on synthetic structures at protein-like density, same machine, best of a warmed run:

| atoms | develop | this PR | speedup |
| --- | --- | --- | --- |
| 2,000 | 0.030 s | 0.004 s | 6.9x |
| 10,000 | 0.160 s | 0.022 s | 7.3x |
| 20,000 | 0.345 s | 0.041 s | 8.4x |
| 40,000 | 0.752 s | 0.081 s | 9.3x |
| 80,000 | 1.579 s | 0.165 s | 9.6x |

End to end, the whole `PDBQTReceptor(pdbqt_string)` call, which also includes parsing and `get_atom_indices_by_residue` that this PR does not touch:

| atoms | develop | this PR | speedup |
| --- | --- | --- | --- |
| 2,000 | 0.045 s | 0.017 s | 2.7x |
| 20,000 | 0.480 s | 0.148 s | 3.2x |
| 80,000 | 2.265 s | 0.755 s | 3.0x |

Measured on Python 3.13.11, NumPy 2.5.1, SciPy 1.18.0, 8 cores. Batching alone accounts for most of it and `workers=-1` contributes roughly another 3.8x on the query itself, so the gain will be smaller on a single core machine but the batching part holds regardless.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please describe): performance, with one small behaviour change noted below

## Checklist:

Please go through the following checklist before submitting the PR: 

- [x] Written a description of the feature or bug fix above. 
- [x] Ran pytest locally and all tests have passed.
- [ ] If applicable, documentation was updated with new feature. 
- [ ] Docstring included for any new classes/functions/methods, or for significantly modifed existing functions. 
- [x] (Optional) new test added to account for new feature.

## Additional Information

Output is unchanged. I checked the new implementation against a verbatim copy of the current one on 40 random structures spanning 2 to 400 atoms and varied density and composition, on 20 non-contiguous index subsets of the kind the annotation lists produce, and on all five pdbqt files in `test/rdkitmol_from_docking_data`. Every bond dict came back identical.

One behaviour change is worth flagging. A single atom input previously raised `TypeError: 'int' object is not subscriptable` in `receptor_pdbqt`, because `query` with `k=1` returns scalars rather than arrays and the slicing could not handle them. It now returns no bonds. `molecule_pdbqt` already returned no bonds for that case through its own early return, so this makes the two agree, but it does turn a crash into a quiet empty result.

`workers=` was added in SciPy 1.6, released December 2020. `requirements.txt` previously pinned no versions at all, so this adds `scipy>=1.6` as the one bound this change actually needs, rather than trying to pin everything.

Adds `test/identify_bonds_test.py` with 7 tests, run against both copies of the function: two and three atom geometries with known bonding, a methane-like case, non-contiguous indices, single atom and empty input, and agreement with a brute force reference over 20 random structures. Six of the seven also pass against `develop`, which is the point, they characterise existing behaviour rather than the new implementation. The seventh is the single atom case described above. Full suite goes from 94 passed / 4 skipped to 101 passed / 4 skipped.
