### PR TITLE
Fixes excessive verbosity of #492

### DIFF
--- a/meeko/chemtempgen.py
+++ b/meeko/chemtempgen.py
@@ -43,6 +43,36 @@ def mol_contains_unexpected_element(mol: Chem.Mol, allowed_elements: list[str] =
     return False
 
 
+def formal_charge_from_cif_value(charge_value: str) -> int:
+    """
+    Convert a ``_chem_comp_atom.charge`` token from a CIF into an int formal charge.
+
+    mmCIF uses ``?`` (value unknown) and ``.`` (value not applicable) as null
+    markers, and CCD entries fetched from the PDB sometimes carry one of these
+    (or a blank) in the charge column instead of an integer. Only these
+    documented null markers are treated as an unspecified formal charge (0,
+    RDKit's default) so a missing charge no longer crashes the whole receptor
+    preparation. Any other token is still parsed as an integer, so a genuinely
+    malformed charge continues to raise (fail-loud) as it did before.
+
+    Parameters
+    ----------
+    charge_value : str
+        The raw charge token read from the CIF atom table.
+
+    Returns
+    -------
+    int
+        The parsed integer formal charge, or 0 for a CIF null marker/blank.
+    """
+    if charge_value is None:
+        return 0
+    token = charge_value.strip()
+    if token in ("", "?", "."):
+        return 0
+    return int(token)
+
+
 def get_atom_idx_by_names(mol: Chem.Mol, wanted_names: set[str] = set()) -> set[int]:
     """
     Get atom idx by atom names
@@ -558,9 +588,9 @@ class ChemicalComponent:
                 # strip double quotes in names
                 raw_name = rdkit_atom.GetProp('atom_id')
                 rdkit_atom.SetProp('atom_id', raw_name.strip('"'))
-            target_charge = atom_cols['charge'][idx]
-            if target_charge!='0':
-                rdkit_atom.SetFormalCharge(int(target_charge)) # this needs to be int for rdkit
+            target_charge = formal_charge_from_cif_value(atom_cols['charge'][idx])
+            if target_charge != 0:
+                rdkit_atom.SetFormalCharge(target_charge) # this needs to be int for rdkit
             rwmol.AddAtom(rdkit_atom)
 
         # Check if rwmol contains unexpected elements

--- a/meeko/chemtempgen.py
+++ b/meeko/chemtempgen.py
@@ -45,15 +45,10 @@ def mol_contains_unexpected_element(mol: Chem.Mol, allowed_elements: list[str] =
 
 def formal_charge_from_cif_value(charge_value: str) -> int:
     """
-    Convert a ``_chem_comp_atom.charge`` token from a CIF into an int formal charge.
+    Convert a ``_chem_comp_atom.charge`` to an int.
 
     mmCIF uses ``?`` (value unknown) and ``.`` (value not applicable) as null
-    markers, and CCD entries fetched from the PDB sometimes carry one of these
-    (or a blank) in the charge column instead of an integer. Only these
-    documented null markers are treated as an unspecified formal charge (0,
-    RDKit's default) so a missing charge no longer crashes the whole receptor
-    preparation. Any other token is still parsed as an integer, so a genuinely
-    malformed charge continues to raise (fail-loud) as it did before.
+    markers, convert these and empty/whitespace str to zero.
 
     Parameters
     ----------

--- a/test/chemtempgen_test.py
+++ b/test/chemtempgen_test.py
@@ -1,10 +1,12 @@
 import pathlib
 import json
+import pytest
 import meeko
 from meeko.chemtempgen import ChemicalComponent
 from meeko.chemtempgen import export_chem_templates_to_json
 from meeko.chemtempgen import build_noncovalent_CC
 from meeko.chemtempgen import build_linked_CCs
+from meeko.chemtempgen import formal_charge_from_cif_value
 
 pkgdir = pathlib.Path(meeko.__file__).parents[1]
 default_template_file = pkgdir / "meeko/data/residue_chem_templates.json"
@@ -64,4 +66,67 @@ def test_add_variants():
         assert isinstance(cc, ChemicalComponent)
 
         assert template_equality_check(default_template_file, cc.resname, "-ccd", cc)
+
+
+# --- Regression tests for issue #491 -----------------------------------------
+# mmCIF uses '?' (value unknown) and '.' (value not applicable) as null markers.
+# CCD templates fetched for unknown residues (e.g. HEM) can carry one of these
+# in the _chem_comp_atom.charge column, which used to crash from_cif() with
+# "ValueError: invalid literal for int() with base 10: '?'" and abort the whole
+# receptor preparation. These tests are network-free and pin the fix in place.
+
+def _write_single_atom_cif(directory: pathlib.Path, charge_token: str) -> str:
+    """Write a minimal CCD-style CIF for a single-Fe residue with the given
+    charge token (faithful to HEM's heme iron) into ``directory`` and return
+    its path. ``directory`` is a pytest tmp_path, so the file is auto-cleaned."""
+    cif = (
+        "data_FEQ\n"
+        "_chem_comp.id FEQ\n"
+        "loop_\n"
+        "_chem_comp_atom.comp_id\n"
+        "_chem_comp_atom.atom_id\n"
+        "_chem_comp_atom.type_symbol\n"
+        "_chem_comp_atom.charge\n"
+        "_chem_comp_atom.pdbx_leaving_atom_flag\n"
+        f"FEQ FE FE {charge_token} N\n"
+    )
+    path = pathlib.Path(directory) / "single_atom.cif"
+    path.write_text(cif)
+    return str(path)
+
+
+def test_formal_charge_from_cif_value():
+    # null markers and blanks are unspecified -> neutral (0)
+    assert formal_charge_from_cif_value("?") == 0
+    assert formal_charge_from_cif_value(".") == 0
+    assert formal_charge_from_cif_value("") == 0
+    assert formal_charge_from_cif_value("  ? ") == 0
+    assert formal_charge_from_cif_value(None) == 0
+    # valid integer charges are preserved
+    assert formal_charge_from_cif_value("0") == 0
+    assert formal_charge_from_cif_value("1") == 1
+    assert formal_charge_from_cif_value("-1") == -1
+    assert formal_charge_from_cif_value("2") == 2
+    # a genuinely malformed (non-null-marker) charge still raises, preserving
+    # the original fail-loud behavior for corrupt CIFs
+    with pytest.raises(ValueError):
+        formal_charge_from_cif_value("n/a")
+
+
+def test_from_cif_unknown_charge_marker_does_not_crash(tmp_path):
+    # Regression: a '?' in the charge column must not raise (issue #491).
+    cif_path = _write_single_atom_cif(tmp_path, "?")
+    cc = ChemicalComponent.from_cif(cif_path, "FEQ")
+    assert cc is not None
+    assert isinstance(cc, ChemicalComponent)
+    # unspecified charge -> neutral formal charge
+    assert cc.rdkit_mol.GetAtomWithIdx(0).GetFormalCharge() == 0
+
+
+def test_from_cif_valid_integer_charge_preserved(tmp_path):
+    # The fix must not change behavior for a real integer charge.
+    cif_path = _write_single_atom_cif(tmp_path, "2")
+    cc = ChemicalComponent.from_cif(cif_path, "FEQ")
+    assert cc is not None
+    assert cc.rdkit_mol.GetAtomWithIdx(0).GetFormalCharge() == 2
 

--- a/test/chemtempgen_test.py
+++ b/test/chemtempgen_test.py
@@ -68,12 +68,9 @@ def test_add_variants():
         assert template_equality_check(default_template_file, cc.resname, "-ccd", cc)
 
 
-# --- Regression tests for issue #491 -----------------------------------------
+# --- Parsing tests for issue #491 -----------------------------------------
 # mmCIF uses '?' (value unknown) and '.' (value not applicable) as null markers.
-# CCD templates fetched for unknown residues (e.g. HEM) can carry one of these
-# in the _chem_comp_atom.charge column, which used to crash from_cif() with
-# "ValueError: invalid literal for int() with base 10: '?'" and abort the whole
-# receptor preparation. These tests are network-free and pin the fix in place.
+# Some residues carry these for formal charges
 
 def _write_single_atom_cif(directory: pathlib.Path, charge_token: str) -> str:
     """Write a minimal CCD-style CIF for a single-Fe residue with the given


### PR DESCRIPTION
Simplified docstring and comment for human readability. Supersedes #492 